### PR TITLE
Add `component` attribute to the outputs of Terraform components that inherit from a base component

### DIFF
--- a/examples/data-sources/utils_stack_config_yaml/data-source.tf
+++ b/examples/data-sources/utils_stack_config_yaml/data-source.tf
@@ -52,3 +52,7 @@ output "uw2_uat_aurora_postgres_vars" {
 output "uw2_uat_aurora_postgres_2_vars" {
   value = local.result[3]["components"]["terraform"]["aurora-postgres-2"]["vars"]
 }
+
+output "uw2_uat_aurora_postgres_2_component" {
+  value = local.result[3]["components"]["terraform"]["aurora-postgres-2"]["component"]
+}

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -125,16 +125,17 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 
 			baseComponentVars := map[interface{}]interface{}{}
 			baseComponentBackend := map[interface{}]interface{}{}
+			baseComponentName := ""
 
-			if baseComponentName, ok2 := componentMap["component"]; ok2 {
-				baseComponent := baseComponentName.(string)
+			if baseComponent, ok2 := componentMap["component"]; ok2 {
+				baseComponentName = baseComponent.(string)
 
-				if baseComponentMap, ok3 := allTerraformComponents[baseComponent].(map[interface{}]interface{}); ok3 {
+				if baseComponentMap, ok3 := allTerraformComponents[baseComponentName].(map[interface{}]interface{}); ok3 {
 					baseComponentVars = baseComponentMap["vars"].(map[interface{}]interface{})
 					baseComponentBackend = baseComponentMap["backend"].(map[interface{}]interface{})[backendType].(map[interface{}]interface{})
 				} else {
 					return nil, errors.New("Terraform component '" + component.(string) + "' defines attribute 'component: " +
-						baseComponent + "', " + "but `" + baseComponent + "' is not defined in the stack '" + stack + "'")
+						baseComponentName + "', " + "but `" + baseComponentName + "' is not defined in the stack '" + stack + "'")
 				}
 			}
 
@@ -152,6 +153,11 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 			comp["vars"] = finalComponentVars
 			comp["backend_type"] = backendType
 			comp["backend"] = finalComponentBackend
+
+			if baseComponentName != "" {
+				comp["component"] = baseComponentName
+			}
+
 			terraformComponents[component] = comp
 		}
 	}


### PR DESCRIPTION
## what
* Add `component` attribute to the outputs of Terraform components that inherit from a base component

## why
* Useful for Terraform modules that use the provider to know if a component has inherited `vars` from a base component
* Used in remote backends to decide whether or not to add the component name to the Terraform workspace name

## test

```
    aurora-postgres:
      vars:
        instance_type: db.r4.large
        cluster_size: 2

    aurora-postgres-2:
      component: aurora-postgres
      vars:
        cluster_size: 3
        instance_type: db.r4.xlarge
```

```
       "aurora-postgres" = {
          "backend" = {
            "acl" = "bucket-owner-full-control"
            "bucket" = "eg-uw2-root-tfstate"
            "dynamodb_table" = "eg-uw2-root-tfstate-lock"
            "encrypt" = true
            "key" = "terraform.tfstate"
            "region" = "us-west-2"
            "role_arn" = "arn:aws:iam::XXXXXXXXXXXX:role/eg-gbl-root-terraform"
            "workspace_key_prefix" = "aurora-postgres"
          }
          "backend_type" = "s3"
          "vars" = {
            "cluster_size" = 2
            "environment" = "uw2"
            "instance_type" = "db.r4.large"
            "namespace" = "eg"
            "region" = "us-west-2"
            "stage" = "uat"
          }
        }
        "aurora-postgres-2" = {
          "backend" = {
            "acl" = "bucket-owner-full-control"
            "bucket" = "eg-uw2-root-tfstate"
            "dynamodb_table" = "eg-uw2-root-tfstate-lock"
            "encrypt" = true
            "key" = "terraform.tfstate"
            "region" = "us-west-2"
            "role_arn" = "arn:aws:iam::XXXXXXXXXXXX:role/eg-gbl-root-terraform"
            "workspace_key_prefix" = "aurora-postgres"
          }
          "backend_type" = "s3"
          "component" = "aurora-postgres"
          "vars" = {
            "cluster_size" = 3
            "environment" = "uw2"
            "instance_type" = "db.r4.xlarge"
            "namespace" = "eg"
            "region" = "us-west-2"
            "stage" = "uat"
          }
        }

```
