### PR TITLE
Add `settings` and `env` sections. Workaround for a deep-merge bug in `mergo.Merge()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## 0.3.0
 
-- Workaround for a bug in `mergo.Merge()` when merging slice of maps in a `for` loop, 
-  it modifies the source of the previous loop iteration if it's a complex map and it get a pointer to it, 
-  not only the destination of the current loop iteration)
+- Workaround for a bug in `mergo.Merge()`. When merging slice of maps in a `for` loop, 
+  `mergo` modifies the source of the previous loop iteration if it's a complex map and `mergo` gets a pointer to it, 
+  not only the destination of the current loop iteration.
 
-- Added `settings` section to YAML stack configurations for Terraform and helmfile components
+- Added `settings` sections to `data_source_stack_config_yaml` data source to provide settings for Terraform and helmfile components
 
-- Added `env` section to YAML stack configurations for Terraform and helmfile components
+- Added `env` sections to `data_source_stack_config_yaml` data source to provide ENV vars for Terraform and helmfile components
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,21 @@
-## 0.1.0
+## 0.3.0
+
+- Workaround for a bug in `mergo.Merge()` when merging slice of maps in a `for` loop, 
+  it modifies the source of the previous loop iteration if it's a complex map and it get a pointer to it, 
+  not only the destination of the current loop iteration)
+
+- Added `settings` section to YAML stack configurations for Terraform and helmfile components
+
+- Added `env` section to YAML stack configurations for Terraform and helmfile components
+
+BACKWARDS INCOMPATIBILITIES / NOTES:
+
 
 ## 0.2.0
 
 - Added `data_source_stack_config_yaml` data source to process YAML stack configurations for Terraform and helmfile components
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
+
+
+## 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.0
 
-- Workaround for a bug in `mergo.Merge()`. When merging slice of maps in a `for` loop, 
+- Workaround for a deep-merge bug in `mergo.Merge()`. When deep-merging slice of maps in a `for` loop, 
   `mergo` modifies the source of the previous loop iteration if it's a complex map and `mergo` gets a pointer to it, 
   not only the destination of the current loop iteration.
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,14 @@ No requirements.
 
 No provider.
 
+## Modules
+
+No Modules.
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 No input.
@@ -14,5 +22,4 @@ No input.
 ## Outputs
 
 No output.
-
 <!-- markdownlint-restore -->

--- a/examples/data-sources/utils_deep_merge_json/data-source.tf
+++ b/examples/data-sources/utils_deep_merge_json/data-source.tf
@@ -2,7 +2,9 @@ terraform {
   required_providers {
     utils = {
       source = "cloudposse/utils"
-      # Install the provider on local computer by running `make install` from the root of the repo
+      # For local development,
+      # install the provider on local computer by running `make install` from the root of the repo,
+      # and uncomment the version below
       # version = "9999.99.99"
     }
   }

--- a/examples/data-sources/utils_deep_merge_yaml/data-source.tf
+++ b/examples/data-sources/utils_deep_merge_yaml/data-source.tf
@@ -2,7 +2,9 @@ terraform {
   required_providers {
     utils = {
       source = "cloudposse/utils"
-      # Install the provider on local computer by running `make install` from the root of the repo
+      # For local development,
+      # install the provider on local computer by running `make install` from the root of the repo,
+      # and uncomment the version below
       # version = "9999.99.99"
     }
   }

--- a/examples/data-sources/utils_stack_config_yaml/data-source.tf
+++ b/examples/data-sources/utils_stack_config_yaml/data-source.tf
@@ -35,8 +35,16 @@ output "uw2_dev_eks_config" {
   value = local.result[0]["components"]["terraform"]["eks"]
 }
 
-output "uw2_uat_eks_vars" {
-  value = local.result[3]["components"]["terraform"]["eks"]["vars"]
+output "uw2_dev_eks_env" {
+  value = local.result[0]["components"]["terraform"]["eks"]["env"]
+}
+
+output "uw2_dev_aurora_postgres_env" {
+  value = local.result[0]["components"]["terraform"]["aurora-postgres"]["env"]
+}
+
+output "uw2_dev_aurora_postgres_2_env" {
+  value = local.result[0]["components"]["terraform"]["aurora-postgres-2"]["env"]
 }
 
 output "uw2_prod_vpc_vars" {
@@ -49,6 +57,10 @@ output "uw2_staging_aurora_postgres_backend" {
 
 output "uw2_staging_aurora_postgres_2_backend" {
   value = local.result[2]["components"]["terraform"]["aurora-postgres-2"]["backend"]
+}
+
+output "uw2_uat_eks_vars" {
+  value = local.result[3]["components"]["terraform"]["eks"]["vars"]
 }
 
 output "uw2_uat_aurora_postgres_vars" {

--- a/examples/data-sources/utils_stack_config_yaml/data-source.tf
+++ b/examples/data-sources/utils_stack_config_yaml/data-source.tf
@@ -5,7 +5,7 @@ terraform {
       # For local development,
       # install the provider on local computer by running `make install` from the root of the repo,
       # and uncomment the version below
-      version = "9999.99.99"
+      # version = "9999.99.99"
     }
   }
 }
@@ -33,6 +33,10 @@ output "uw2_dev_datadog_vars" {
 
 output "uw2_dev_eks_config" {
   value = local.result[0]["components"]["terraform"]["eks"]
+}
+
+output "uw2_uat_eks_vars" {
+  value = local.result[3]["components"]["terraform"]["eks"]["vars"]
 }
 
 output "uw2_prod_vpc_vars" {
@@ -65,4 +69,8 @@ output "uw2_uat_aurora_postgres_2_settings" {
 
 output "uw2_uat_aurora_postgres_2_component" {
   value = local.result[3]["components"]["terraform"]["aurora-postgres-2"]["component"]
+}
+
+output "uw2_uat_eks_settings" {
+  value = local.result[3]["components"]["terraform"]["eks"]["settings"]
 }

--- a/examples/data-sources/utils_stack_config_yaml/data-source.tf
+++ b/examples/data-sources/utils_stack_config_yaml/data-source.tf
@@ -2,8 +2,10 @@ terraform {
   required_providers {
     utils = {
       source = "cloudposse/utils"
-      # Install the provider on local computer by running `make install` from the root of the repo
-      # version = "9999.99.99"
+      # For local development,
+      # install the provider on local computer by running `make install` from the root of the repo,
+      # and uncomment the version below
+      version = "9999.99.99"
     }
   }
 }
@@ -49,8 +51,16 @@ output "uw2_uat_aurora_postgres_vars" {
   value = local.result[3]["components"]["terraform"]["aurora-postgres"]["vars"]
 }
 
+output "uw2_uat_aurora_postgres_settings" {
+  value = local.result[3]["components"]["terraform"]["aurora-postgres"]["settings"]
+}
+
 output "uw2_uat_aurora_postgres_2_vars" {
   value = local.result[3]["components"]["terraform"]["aurora-postgres-2"]["vars"]
+}
+
+output "uw2_uat_aurora_postgres_2_settings" {
+  value = local.result[3]["components"]["terraform"]["aurora-postgres-2"]["settings"]
 }
 
 output "uw2_uat_aurora_postgres_2_component" {

--- a/examples/data-sources/utils_stack_config_yaml/stacks/globals.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/globals.yaml
@@ -302,6 +302,15 @@ components:
           workspace_enabled: false
           autodeploy: false
 
+    aurora-postgres-2:
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
+
     efs:
       backend:
         s3:

--- a/examples/data-sources/utils_stack_config_yaml/stacks/globals.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/globals.yaml
@@ -27,175 +27,77 @@ components:
         s3:
           workspace_key_prefix: "tfstate-backend"
           role_arn: null
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     account:
       backend:
         s3:
           workspace_key_prefix: "account"
           role_arn: null
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     account-map:
       backend:
         s3:
           workspace_key_prefix: "account-map"
           role_arn: null
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     account-settings:
       backend:
         s3:
           workspace_key_prefix: "account-settings"
           role_arn: null
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     dns-delegated:
       backend:
         s3:
           workspace_key_prefix: "dns-delegated"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     dns-primary:
       backend:
         s3:
           workspace_key_prefix: "dns-primary"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     eks:
       backend:
         s3:
           workspace_key_prefix: "eks"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     eks-iam:
       backend:
         s3:
           workspace_key_prefix: "eks-iam"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     iam-delegated-roles:
       backend:
         s3:
           workspace_key_prefix: "iam-delegated-roles"
           role_arn: null
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     iam-primary-roles:
       backend:
         s3:
           workspace_key_prefix: "iam-primary-roles"
           role_arn: null
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     spotinst-integration:
       backend:
         s3:
           workspace_key_prefix: "spotinst-integration"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     sso:
       backend:
         s3:
           workspace_key_prefix: "sso"
           role_arn: null
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     config-bucket:
       backend:
         s3:
           workspace_key_prefix: "config-bucket"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     cloudtrail-bucket:
       backend:
         s3:
           workspace_key_prefix: "cloudtrail-bucket"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     cloudtrail:
       vars:
@@ -204,37 +106,16 @@ components:
       backend:
         s3:
           workspace_key_prefix: "cloudtrail"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     transit-gateway:
       backend:
         s3:
           workspace_key_prefix: "transit-gateway"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     vpc-flow-logs-bucket:
       backend:
         s3:
           workspace_key_prefix: "vpc-flow-logs-bucket"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     vpc:
       vars:
@@ -246,103 +127,38 @@ components:
       backend:
         s3:
           workspace_key_prefix: "vpc"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     ecr:
       backend:
         s3:
           workspace_key_prefix: "ecr"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     datadog-integration:
       backend:
         s3:
           workspace_key_prefix: "datadog-integration"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     datadog-monitor:
       backend:
         s3:
           workspace_key_prefix: "datadog-monitor"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     aurora-postgres:
       backend:
         s3:
           workspace_key_prefix: "aurora-postgres"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
-
-    aurora-postgres-2:
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     efs:
       backend:
         s3:
           workspace_key_prefix: "efs"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     mq-broker:
       backend:
         s3:
           workspace_key_prefix: "mq-broker"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false
 
     ses:
       backend:
         s3:
           workspace_key_prefix: "ses"
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-        terraform_cloud:
-          workspace_enabled: false
-          autodeploy: false

--- a/examples/data-sources/utils_stack_config_yaml/stacks/globals.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/globals.yaml
@@ -27,77 +27,175 @@ components:
         s3:
           workspace_key_prefix: "tfstate-backend"
           role_arn: null
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     account:
       backend:
         s3:
           workspace_key_prefix: "account"
           role_arn: null
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     account-map:
       backend:
         s3:
           workspace_key_prefix: "account-map"
           role_arn: null
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     account-settings:
       backend:
         s3:
           workspace_key_prefix: "account-settings"
           role_arn: null
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     dns-delegated:
       backend:
         s3:
           workspace_key_prefix: "dns-delegated"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     dns-primary:
       backend:
         s3:
           workspace_key_prefix: "dns-primary"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     eks:
       backend:
         s3:
           workspace_key_prefix: "eks"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     eks-iam:
       backend:
         s3:
           workspace_key_prefix: "eks-iam"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     iam-delegated-roles:
       backend:
         s3:
           workspace_key_prefix: "iam-delegated-roles"
           role_arn: null
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     iam-primary-roles:
       backend:
         s3:
           workspace_key_prefix: "iam-primary-roles"
           role_arn: null
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     spotinst-integration:
       backend:
         s3:
           workspace_key_prefix: "spotinst-integration"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     sso:
       backend:
         s3:
           workspace_key_prefix: "sso"
           role_arn: null
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     config-bucket:
       backend:
         s3:
           workspace_key_prefix: "config-bucket"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     cloudtrail-bucket:
       backend:
         s3:
           workspace_key_prefix: "cloudtrail-bucket"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     cloudtrail:
       vars:
@@ -106,16 +204,37 @@ components:
       backend:
         s3:
           workspace_key_prefix: "cloudtrail"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     transit-gateway:
       backend:
         s3:
           workspace_key_prefix: "transit-gateway"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     vpc-flow-logs-bucket:
       backend:
         s3:
           workspace_key_prefix: "vpc-flow-logs-bucket"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     vpc:
       vars:
@@ -127,38 +246,94 @@ components:
       backend:
         s3:
           workspace_key_prefix: "vpc"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     ecr:
       backend:
         s3:
           workspace_key_prefix: "ecr"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     datadog-integration:
       backend:
         s3:
           workspace_key_prefix: "datadog-integration"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     datadog-monitor:
       backend:
         s3:
           workspace_key_prefix: "datadog-monitor"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     aurora-postgres:
       backend:
         s3:
           workspace_key_prefix: "aurora-postgres"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     efs:
       backend:
         s3:
           workspace_key_prefix: "efs"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     mq-broker:
       backend:
         s3:
           workspace_key_prefix: "mq-broker"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false
 
     ses:
       backend:
         s3:
           workspace_key_prefix: "ses"
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+        terraform_cloud:
+          workspace_enabled: false
+          autodeploy: false

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
@@ -98,3 +98,7 @@ components:
           - "env:uw2-dev"
           - "region:us-west-2"
           - "stage:dev"
+      env:
+        ENV_DD_TEST_1: dd1
+        ENV_DD_TEST_2: dd2
+        ENV_DD_TEST_3: dd3

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
@@ -47,7 +47,7 @@ components:
         spacelift:
           workspace_enabled: true
           autodeploy: true
-          branch: ""
+          branch: "test"
           triggers: []
 
     vpc:
@@ -73,7 +73,7 @@ components:
         spacelift:
           workspace_enabled: true
           autodeploy: true
-          branch: ""
+          branch: "dev"
           triggers: []
 
   helmfile:

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
@@ -49,6 +49,10 @@ components:
           autodeploy: true
           branch: "test"
           triggers: []
+      env:
+        ENV_TEST_1: test1_override
+        ENV_TEST_2: test2_override
+        ENV_TEST_4: test4
 
     vpc:
       vars:
@@ -64,6 +68,11 @@ components:
       vars:
         instance_type: db.r4.large
         cluster_size: 1
+      env:
+        ENV_TEST_4: test4
+        ENV_TEST_5: test5
+        ENV_TEST_6: test6
+        ENV_TEST_7: test7
 
     aurora-postgres-2:
       component: aurora-postgres
@@ -75,6 +84,10 @@ components:
           autodeploy: true
           branch: "dev"
           triggers: []
+      env:
+        ENV_TEST_1: test1_override2
+        ENV_TEST_2: test2_override2
+        ENV_TEST_8: test8
 
   helmfile:
 

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
@@ -64,12 +64,6 @@ components:
       vars:
         instance_type: db.r4.large
         cluster_size: 1
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-          branch: ""
-          triggers: []
 
     aurora-postgres-2:
       component: aurora-postgres

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml
@@ -21,6 +21,12 @@ components:
         zone_config:
           - subdomain: dev
             zone_name: uw2.example.com
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     eks:
       vars:
@@ -37,20 +43,44 @@ components:
             instance_types: null
             ami_type: "AL2_x86_64"
             tags: null
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
     vpc:
       vars:
         cidr_block: "10.114.0.0/18"
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
     aurora-postgres:
       vars:
         instance_type: db.r4.large
         cluster_size: 1
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     aurora-postgres-2:
       component: aurora-postgres
       vars:
         instance_type: db.r4.xlarge
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
   helmfile:
 

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-globals.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-globals.yaml
@@ -17,10 +17,16 @@ components:
     vpc:
       vars:
         availability_zones: ["us-west-2b", "us-west-2c", "us-west-2d"]
+      settings:
+        spacelift:
+          workspace_enabled: true
 
     eks:
       vars:
         region_availability_zones: ["us-west-2b", "us-west-2c", "us-west-2d"]
+      settings:
+        spacelift:
+          workspace_enabled: false
 
   helmfile:
     datadog:

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-globals.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-globals.yaml
@@ -12,6 +12,10 @@ terraform:
     spacelift:
       workspace_enabled: false
       autodeploy: false
+  env:
+    ENV_TEST_1: test1
+    ENV_TEST_2: test2
+    ENV_TEST_3: test3
 
 helmfile:
   vars:

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-globals.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-globals.yaml
@@ -7,6 +7,11 @@ vars:
 
 terraform:
   vars: {}
+  settings:
+    version: 0
+    spacelift:
+      workspace_enabled: false
+      autodeploy: false
 
 helmfile:
   vars:
@@ -17,16 +22,10 @@ components:
     vpc:
       vars:
         availability_zones: ["us-west-2b", "us-west-2c", "us-west-2d"]
-      settings:
-        spacelift:
-          workspace_enabled: true
 
     eks:
       vars:
         region_availability_zones: ["us-west-2b", "us-west-2c", "us-west-2d"]
-      settings:
-        spacelift:
-          workspace_enabled: true
 
   helmfile:
     datadog:

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-globals.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-globals.yaml
@@ -26,7 +26,7 @@ components:
         region_availability_zones: ["us-west-2b", "us-west-2c", "us-west-2d"]
       settings:
         spacelift:
-          workspace_enabled: false
+          workspace_enabled: true
 
   helmfile:
     datadog:

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-prod.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-prod.yaml
@@ -21,6 +21,12 @@ components:
         zone_config:
           - subdomain: prod
             zone_name: uw2.example.com
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     eks:
       vars:
@@ -37,20 +43,44 @@ components:
             instance_types: null
             ami_type: "AL2_x86_64"
             tags: null
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
     vpc:
       vars:
         cidr_block: "10.116.0.0/18"
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     aurora-postgres:
       vars:
         instance_type: db.r4.large
         cluster_size: 3
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     aurora-postgres-2:
       component: aurora-postgres
       vars:
         instance_type: db.r4.xlarge
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
   helmfile:
 

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-prod.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-prod.yaml
@@ -49,6 +49,10 @@ components:
           autodeploy: true
           branch: ""
           triggers: []
+      env:
+        ENV_TEST_1: test1_override
+        ENV_TEST_2: test2_override
+        ENV_TEST_4: test4
 
     vpc:
       vars:
@@ -64,6 +68,11 @@ components:
       vars:
         instance_type: db.r4.large
         cluster_size: 3
+      env:
+        ENV_TEST_4: test4
+        ENV_TEST_5: test5
+        ENV_TEST_6: test6
+        ENV_TEST_7: test7
 
     aurora-postgres-2:
       component: aurora-postgres
@@ -75,6 +84,10 @@ components:
           autodeploy: true
           branch: ""
           triggers: []
+      env:
+        ENV_TEST_1: test1_override2
+        ENV_TEST_2: test2_override2
+        ENV_TEST_8: test8
 
   helmfile:
 
@@ -85,3 +98,7 @@ components:
           - "env:uw2-prod"
           - "region:us-west-2"
           - "stage:prod"
+      env:
+        ENV_DD_TEST_1: dd1
+        ENV_DD_TEST_2: dd2
+        ENV_DD_TEST_3: dd3

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-prod.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-prod.yaml
@@ -64,12 +64,6 @@ components:
       vars:
         instance_type: db.r4.large
         cluster_size: 3
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-          branch: ""
-          triggers: []
 
     aurora-postgres-2:
       component: aurora-postgres

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-staging.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-staging.yaml
@@ -21,6 +21,12 @@ components:
         zone_config:
           - subdomain: staging
             zone_name: uw2.example.com
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     eks:
       vars:
@@ -37,20 +43,44 @@ components:
             instance_types: null
             ami_type: "AL2_x86_64"
             tags: null
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
     vpc:
       vars:
         cidr_block: "10.118.0.0/18"
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     aurora-postgres:
       vars:
         instance_type: db.r4.large
         cluster_size: 2
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     aurora-postgres-2:
       component: aurora-postgres
       vars:
         instance_type: db.r4.xlarge
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
   helmfile:
 

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-staging.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-staging.yaml
@@ -64,12 +64,6 @@ components:
       vars:
         instance_type: db.r4.large
         cluster_size: 2
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-          branch: ""
-          triggers: []
 
     aurora-postgres-2:
       component: aurora-postgres

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-staging.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-staging.yaml
@@ -49,6 +49,10 @@ components:
           autodeploy: true
           branch: ""
           triggers: []
+      env:
+        ENV_TEST_1: test1_override
+        ENV_TEST_2: test2_override
+        ENV_TEST_4: test4
 
     vpc:
       vars:
@@ -64,6 +68,11 @@ components:
       vars:
         instance_type: db.r4.large
         cluster_size: 2
+      env:
+        ENV_TEST_4: test4
+        ENV_TEST_5: test5
+        ENV_TEST_6: test6
+        ENV_TEST_7: test7
 
     aurora-postgres-2:
       component: aurora-postgres
@@ -75,6 +84,10 @@ components:
           autodeploy: true
           branch: ""
           triggers: []
+      env:
+        ENV_TEST_1: test1_override2
+        ENV_TEST_2: test2_override2
+        ENV_TEST_8: test8
 
   helmfile:
 
@@ -85,3 +98,7 @@ components:
           - "env:uw2-staging"
           - "region:us-west-2"
           - "stage:staging"
+      env:
+        ENV_DD_TEST_1: dd1
+        ENV_DD_TEST_2: dd2
+        ENV_DD_TEST_3: dd3

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
@@ -21,6 +21,12 @@ components:
         zone_config:
           - subdomain: uat
             zone_name: uw2.example.com
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     eks:
       vars:
@@ -37,21 +43,45 @@ components:
             instance_types: null
             ami_type: "AL2_x86_64"
             tags: null
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
     vpc:
       vars:
         cidr_block: "10.120.0.0/18"
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     aurora-postgres:
       vars:
         instance_type: db.r4.large
         cluster_size: 2
+      settings:
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+          branch: ""
+          triggers: []
 
     aurora-postgres-2:
       component: aurora-postgres
       vars:
         cluster_size: 3
         instance_type: db.r4.xlarge
+      settings:
+        spacelift:
+          workspace_enabled: true
+          autodeploy: true
+          branch: ""
+          triggers: []
 
   helmfile:
 

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
@@ -75,6 +75,7 @@ components:
           workspace_enabled: true
           autodeploy: true
           branch: "test"
+          triggers: []
 
   helmfile:
 

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
@@ -49,6 +49,10 @@ components:
           autodeploy: false
           branch: "main"
           triggers: []
+      env:
+        ENV_TEST_1: test1_override
+        ENV_TEST_2: test2_override
+        ENV_TEST_4: test4
 
     vpc:
       vars:
@@ -71,6 +75,11 @@ components:
           autodeploy: false
           branch: "test3"
           triggers: ["4", "5", "6"]
+      env:
+        ENV_TEST_4: test4
+        ENV_TEST_5: test5
+        ENV_TEST_6: test6
+        ENV_TEST_7: test7
 
     aurora-postgres-2:
       component: aurora-postgres
@@ -84,6 +93,10 @@ components:
           autodeploy: true
           branch: "test4"
           triggers: ["7", "8", "9"]
+      env:
+        ENV_TEST_1: test1_override2
+        ENV_TEST_2: test2_override2
+        ENV_TEST_8: test8
 
   helmfile:
 
@@ -94,3 +107,7 @@ components:
           - "env:uw2-uat"
           - "region:us-west-2"
           - "stage:uat"
+      env:
+        ENV_DD_TEST_1: dd1
+        ENV_DD_TEST_2: dd2
+        ENV_DD_TEST_3: dd3

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
@@ -64,12 +64,6 @@ components:
       vars:
         instance_type: db.r4.large
         cluster_size: 2
-      settings:
-        spacelift:
-          workspace_enabled: false
-          autodeploy: false
-          branch: ""
-          triggers: []
 
     aurora-postgres-2:
       component: aurora-postgres
@@ -80,8 +74,7 @@ components:
         spacelift:
           workspace_enabled: true
           autodeploy: true
-          branch: ""
-          triggers: []
+          branch: "test"
 
   helmfile:
 

--- a/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml
@@ -46,8 +46,8 @@ components:
       settings:
         spacelift:
           workspace_enabled: true
-          autodeploy: true
-          branch: ""
+          autodeploy: false
+          branch: "main"
           triggers: []
 
     vpc:
@@ -57,13 +57,20 @@ components:
         spacelift:
           workspace_enabled: true
           autodeploy: false
-          branch: ""
+          branch: "main"
           triggers: []
 
     aurora-postgres:
       vars:
         instance_type: db.r4.large
         cluster_size: 2
+      settings:
+        version: 1
+        spacelift:
+          workspace_enabled: false
+          autodeploy: false
+          branch: "test3"
+          triggers: ["4", "5", "6"]
 
     aurora-postgres-2:
       component: aurora-postgres
@@ -71,11 +78,12 @@ components:
         cluster_size: 3
         instance_type: db.r4.xlarge
       settings:
+        version: 2
         spacelift:
           workspace_enabled: true
           autodeploy: true
-          branch: "test"
-          triggers: []
+          branch: "test4"
+          triggers: ["7", "8", "9"]
 
   helmfile:
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,9 @@ go 1.15
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.2
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3
 	github.com/imdario/mergo v0.3.11
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/imdario/mergo v0.3.11
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -194,14 +194,16 @@ github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.12.0 h1:Tb1VC2gqArl9EJziJjoazep2MyxMk00tnNKV/rgMba0=
 github.com/hashicorp/terraform-exec v0.12.0/go.mod h1:SGhto91bVRlgXQWcJ5znSz+29UZIa8kpBbkGwQ+g9E8=
+github.com/hashicorp/terraform-exec v0.13.0 h1:1Pth+pdWJAufJuWWjaVOVNEkoRTOjGn3hQpAqj4aPdg=
+github.com/hashicorp/terraform-exec v0.13.0/go.mod h1:SGhto91bVRlgXQWcJ5znSz+29UZIa8kpBbkGwQ+g9E8=
 github.com/hashicorp/terraform-json v0.8.0 h1:XObQ3PgqU52YLQKEaJ08QtUshAfN3yu4u8ebSW0vztc=
 github.com/hashicorp/terraform-json v0.8.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/hashicorp/terraform-plugin-docs v0.4.0 h1:xJIXsMzBFwBvC1zcjoNz743GL2tNEfYFFU9+Hjp4Uek=
 github.com/hashicorp/terraform-plugin-docs v0.4.0/go.mod h1:fKj/V3t45tiXpSlUms/0G4OrBayyWpbUJ4WtLjBkINU=
 github.com/hashicorp/terraform-plugin-go v0.2.1 h1:EW/R8bB2Zbkjmugzsy1d27yS8/0454b3MtYHkzOknqA=
 github.com/hashicorp/terraform-plugin-go v0.2.1/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.2 h1:8oo4eMtv3nEZGqe8W0UzMxKnKWuwS/Tb2YyIFJkL59g=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.2/go.mod h1:jgCWyjKf1BRqzuA3IPJb6PJ2YY86ePJurX9xfJtuYNU=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3 h1:DGnxpIYRHXQZb2TOlQ1OCEYxoRQrAcbLIcYm8kvbFuU=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3/go.mod h1:5wrrTcxbSaQXamCDbHZTHk6yTF9OEZaOvQ9fvLXBE3o=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -277,6 +279,8 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5w=

--- a/internal/convert/json.go
+++ b/internal/convert/json.go
@@ -2,8 +2,8 @@ package convert
 
 import "encoding/json"
 
-// JSONToMap takes a JSON string as input and returns a map[string]interface{}
-func JSONToMap(input string) (map[string]interface{}, error) {
+// JSONToMapOfInterfaces takes a JSON string as input and returns a map[string]interface{}
+func JSONToMapOfInterfaces(input string) (map[string]interface{}, error) {
 	var data map[string]interface{}
 	byt := []byte(input)
 
@@ -17,7 +17,7 @@ func JSONToMap(input string) (map[string]interface{}, error) {
 func JSONSliceOfInterfaceToSliceOfMaps(input []interface{}) ([]map[interface{}]interface{}, error) {
 	outputMap := make([]map[interface{}]interface{}, 0)
 	for _, current := range input {
-		data, err := JSONToMap(current.(string))
+		data, err := JSONToMapOfInterfaces(current.(string))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/convert/json_test.go
+++ b/internal/convert/json_test.go
@@ -6,15 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJSONToMap(t *testing.T) {
+func TestJSONToMapOfInterfaces(t *testing.T) {
 	input := "{\"hello\": \"world\"}"
-	result, err := JSONToMap(input)
+	result, err := JSONToMapOfInterfaces(input)
 	assert.Nil(t, err)
 	assert.Equal(t, result["hello"], "world")
 }
 
-func TestJSONToMapRedPath(t *testing.T) {
+func TestJSONToMapOfInterfacesRedPath(t *testing.T) {
 	input := "Not JSON"
-	_, err := JSONToMap(input)
+	_, err := JSONToMapOfInterfaces(input)
 	assert.NotNil(t, err)
 }

--- a/internal/convert/map.go
+++ b/internal/convert/map.go
@@ -1,0 +1,19 @@
+package convert
+
+// MapsOfStringsToMapsOfInterfaces takes map[string]interface{} and returns map[interface{}]interface{}
+func MapsOfStringsToMapsOfInterfaces(input map[string]interface{}) map[interface{}]interface{} {
+	output := map[interface{}]interface{}{}
+	for k, v := range input {
+		output[k] = v
+	}
+	return output
+}
+
+// MapsOfInterfacesToMapsOfStrings takes map[interface{}]interface{} and returns map[string]interface{}
+func MapsOfInterfacesToMapsOfStrings(input map[interface{}]interface{}) map[string]interface{} {
+	output := map[string]interface{}{}
+	for k, v := range input {
+		output[k.(string)] = v
+	}
+	return output
+}

--- a/internal/convert/slice.go
+++ b/internal/convert/slice.go
@@ -15,3 +15,12 @@ func SliceOfInterfacesToSliceOfStrings(input []interface{}) ([]string, error) {
 
 	return output, nil
 }
+
+// SliceOfMapsOfStringsToSliceOfMapsOfInterfaces takes a slice of map[string]interface{} and returns a slice of map[interface{}]interface{}
+func SliceOfMapsOfStringsToSliceOfMapsOfInterfaces(input []map[string]interface{}) []map[interface{}]interface{} {
+	output := make([]map[interface{}]interface{}, 0)
+	for k, v := range input {
+		output = append(output, map[interface{}]interface{}{k: v})
+	}
+	return output
+}

--- a/internal/convert/slice.go
+++ b/internal/convert/slice.go
@@ -5,7 +5,7 @@ import "github.com/pkg/errors"
 // SliceOfInterfacesToSliceOfStrings takes a slice of interfaces and converts it to a slice of strings
 func SliceOfInterfacesToSliceOfStrings(input []interface{}) ([]string, error) {
 	if input == nil {
-		return nil, errors.New("imput must not be nil")
+		return nil, errors.New("input must not be nil")
 	}
 
 	output := make([]string, 0)

--- a/internal/convert/yaml.go
+++ b/internal/convert/yaml.go
@@ -2,17 +2,6 @@ package convert
 
 import "gopkg.in/yaml.v2"
 
-// YAMLToMap takes a YAML string as input and returns a map[interface{}]interface{}
-func YAMLToMap(input string) (map[interface{}]interface{}, error) {
-	var data map[interface{}]interface{}
-	byt := []byte(input)
-
-	if err := yaml.Unmarshal(byt, &data); err != nil {
-		return nil, err
-	}
-	return data, nil
-}
-
 // YAMLToMapOfInterfaces takes a YAML string as input and returns a map[interface{}]interface{}
 func YAMLToMapOfInterfaces(input string) (map[interface{}]interface{}, error) {
 	var data map[interface{}]interface{}
@@ -28,7 +17,7 @@ func YAMLToMapOfInterfaces(input string) (map[interface{}]interface{}, error) {
 func YAMLSliceOfInterfaceToSliceOfMaps(input []interface{}) ([]map[interface{}]interface{}, error) {
 	output := make([]map[interface{}]interface{}, 0)
 	for _, current := range input {
-		data, err := YAMLToMap(current.(string))
+		data, err := YAMLToMapOfInterfaces(current.(string))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/convert/yaml.go
+++ b/internal/convert/yaml.go
@@ -26,13 +26,13 @@ func YAMLToMapOfInterfaces(input string) (map[interface{}]interface{}, error) {
 
 // YAMLSliceOfInterfaceToSliceOfMaps takes a slice of interfaces as input and returns a slice of map[interface{}]interface{}
 func YAMLSliceOfInterfaceToSliceOfMaps(input []interface{}) ([]map[interface{}]interface{}, error) {
-	outputMap := make([]map[interface{}]interface{}, 0)
+	output := make([]map[interface{}]interface{}, 0)
 	for _, current := range input {
 		data, err := YAMLToMap(current.(string))
 		if err != nil {
 			return nil, err
 		}
-		outputMap = append(outputMap, data)
+		output = append(output, data)
 	}
-	return outputMap, nil
+	return output, nil
 }

--- a/internal/convert/yaml_test.go
+++ b/internal/convert/yaml_test.go
@@ -6,16 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestYAMLToMap(t *testing.T) {
+func TestYAMLToMapOfInterfaces(t *testing.T) {
 	input := `---
 hello: world`
-	result, err := YAMLToMap(input)
+	result, err := YAMLToMapOfInterfaces(input)
 	assert.Nil(t, err)
 	assert.Equal(t, result["hello"], "world")
 }
 
-func TestYAMLToMapRedPath(t *testing.T) {
+func TestYAMLToMapOfInterfacesRedPath(t *testing.T) {
 	input := "Not YAML"
-	_, err := YAMLToMap(input)
+	_, err := YAMLToMapOfInterfaces(input)
 	assert.NotNil(t, err)
 }

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -9,7 +9,7 @@ func Merge(inputs []map[interface{}]interface{}) (map[interface{}]interface{}, e
 	merged := map[interface{}]interface{}{}
 
 	for index := range inputs {
-		if err := mergo.Merge(&merged, inputs[index], mergo.WithOverride, mergo.WithOverwriteWithEmptyValue); err != nil {
+		if err := mergo.Merge(&merged, inputs[index], mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTypeCheck); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -13,7 +13,7 @@ func Merge(inputs []map[interface{}]interface{}) (map[interface{}]interface{}, e
 		current := inputs[index]
 
 		// Due to a bug in `mergo.Merge`
-		// (in the `for` loop, it DOES modify the source of the previous loop iteration if it's a complex map and it get a pointer to it,
+		// (in the `for` loop, it DOES modify the source of the previous loop iteration if it's a complex map and `mergo` get a pointer to it,
 		// not only the destination of the current loop iteration),
 		// we don't give it our maps directly; we convert them to YAML strings and then back to `Go` maps,
 		// so `mergo` does not have access to the original pointers

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -4,7 +4,7 @@ import (
 	"github.com/imdario/mergo"
 )
 
-// Merge takes a list of maps as input and returns a single map with the merged contents
+// Merge takes a list of maps of interface as input and returns a single map with the merged contents
 func Merge(inputs []map[interface{}]interface{}) (map[interface{}]interface{}, error) {
 	merged := map[interface{}]interface{}{}
 

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -12,9 +12,10 @@ func Merge(inputs []map[interface{}]interface{}) (map[interface{}]interface{}, e
 	for index := range inputs {
 		current := inputs[index]
 
-		// Due to a bug in `mergo.Merge` (it DOES modify the source if it's a complex map and it get a pointer to it, not only the destination),
-		// we don't give it our maps directly; we convert them to YAML and then back to `Go` maps, so `mergo.Merge` does not have
-		// access to the original pointers
+		// Due to a bug in `mergo.Merge`
+		// (in the `for` loop, it DOES modify the source if it's a complex map and it get a pointer to it, not only the destination),
+		// we don't give it our maps directly; we convert them to YAML strings and then back to `Go` maps,
+		// so `mergo` does not have access to the original pointers
 		yamlCurrent, err := yaml.Marshal(current)
 		if err != nil {
 			return nil, err

--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -13,7 +13,8 @@ func Merge(inputs []map[interface{}]interface{}) (map[interface{}]interface{}, e
 		current := inputs[index]
 
 		// Due to a bug in `mergo.Merge`
-		// (in the `for` loop, it DOES modify the source if it's a complex map and it get a pointer to it, not only the destination),
+		// (in the `for` loop, it DOES modify the source of the previous loop iteration if it's a complex map and it get a pointer to it,
+		// not only the destination of the current loop iteration),
 		// we don't give it our maps directly; we convert them to YAML strings and then back to `Go` maps,
 		// so `mergo` does not have access to the original pointers
 		yamlCurrent, err := yaml.Marshal(current)

--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestMergeBasic(t *testing.T) {
-	map1 := map[string]interface{}{"foo": "bar"}
-	map2 := map[string]interface{}{"baz": "bat"}
+	map1 := map[interface{}]interface{}{"foo": "bar"}
+	map2 := map[interface{}]interface{}{"baz": "bat"}
 
-	inputs := []map[string]interface{}{map1, map2}
-	expected := map[string]interface{}{"foo": "bar", "baz": "bat"}
+	inputs := []map[interface{}]interface{}{map1, map2}
+	expected := map[interface{}]interface{}{"foo": "bar", "baz": "bat"}
 
 	result, err := Merge(inputs)
 	assert.Nil(t, err)
@@ -19,12 +19,12 @@ func TestMergeBasic(t *testing.T) {
 }
 
 func TestMergeBasicOverride(t *testing.T) {
-	map1 := map[string]interface{}{"foo": "bar"}
-	map2 := map[string]interface{}{"baz": "bat"}
-	map3 := map[string]interface{}{"foo": "ood"}
+	map1 := map[interface{}]interface{}{"foo": "bar"}
+	map2 := map[interface{}]interface{}{"baz": "bat"}
+	map3 := map[interface{}]interface{}{"foo": "ood"}
 
-	inputs := []map[string]interface{}{map1, map2, map3}
-	expected := map[string]interface{}{"foo": "ood", "baz": "bat"}
+	inputs := []map[interface{}]interface{}{map1, map2, map3}
+	expected := map[interface{}]interface{}{"foo": "ood", "baz": "bat"}
 
 	result, err := Merge(inputs)
 	assert.Nil(t, err)

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -88,9 +88,9 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 	helmfileSettings := map[interface{}]interface{}{}
 	backendType := "s3"
 	backend := map[interface{}]interface{}{}
-	terraformComponents := map[interface{}]interface{}{}
-	helmfileComponents := map[interface{}]interface{}{}
-	allComponents := map[interface{}]interface{}{}
+	terraformComponents := map[string]interface{}{}
+	helmfileComponents := map[string]interface{}{}
+	allComponents := map[string]interface{}{}
 
 	if i, ok := config["vars"]; ok {
 		globalVars = i.(map[interface{}]interface{})
@@ -126,8 +126,9 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 		helmfileSettings = i.(map[interface{}]interface{})
 	}
 
-	if allTerraformComponents, ok := config["components"].(map[interface{}]interface{})["terraform"].(map[interface{}]interface{}); ok {
-		for component, v := range allTerraformComponents {
+	if allTerraformComponents, ok := config["components"].(map[interface{}]interface{})["terraform"]; ok {
+		allTerraformComponentsMap := allTerraformComponents.(map[interface{}]interface{})
+		for component, v := range allTerraformComponentsMap {
 			componentMap := v.(map[interface{}]interface{})
 
 			componentVars := map[interface{}]interface{}{}
@@ -152,7 +153,7 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 			if baseComponent, baseComponentExist := componentMap["component"]; baseComponentExist {
 				baseComponentName = baseComponent.(string)
 
-				if baseComponentSection, baseComponentSectionExist := allTerraformComponents[baseComponentName]; baseComponentSectionExist {
+				if baseComponentSection, baseComponentSectionExist := allTerraformComponentsMap[baseComponentName]; baseComponentSectionExist {
 					baseComponentMap := baseComponentSection.(map[interface{}]interface{})
 					baseComponentVars = baseComponentMap["vars"].(map[interface{}]interface{})
 
@@ -190,12 +191,13 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 				comp["component"] = baseComponentName
 			}
 
-			terraformComponents[component] = comp
+			terraformComponents[component.(string)] = comp
 		}
 	}
 
-	if allHelmfileComponents, ok := config["components"].(map[interface{}]interface{})["helmfile"].(map[interface{}]interface{}); ok {
-		for component, v := range allHelmfileComponents {
+	if allHelmfileComponents, ok := config["components"].(map[interface{}]interface{})["helmfile"]; ok {
+		allHelmfileComponentsMap := allHelmfileComponents.(map[interface{}]interface{})
+		for component, v := range allHelmfileComponentsMap {
 			componentMap := v.(map[interface{}]interface{})
 
 			componentVars := map[interface{}]interface{}{}
@@ -221,7 +223,7 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 			comp := map[string]interface{}{}
 			comp["vars"] = finalComponentVars
 			comp["settings"] = finalComponentSettings
-			helmfileComponents[component] = comp
+			helmfileComponents[component.(string)] = comp
 		}
 	}
 

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -128,6 +128,7 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 
 	if allTerraformComponents, ok := config["components"].(map[interface{}]interface{})["terraform"]; ok {
 		allTerraformComponentsMap := allTerraformComponents.(map[interface{}]interface{})
+
 		for component, v := range allTerraformComponentsMap {
 			componentMap := v.(map[interface{}]interface{})
 
@@ -197,6 +198,7 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 
 	if allHelmfileComponents, ok := config["components"].(map[interface{}]interface{})["helmfile"]; ok {
 		allHelmfileComponentsMap := allHelmfileComponents.(map[interface{}]interface{})
+
 		for component, v := range allHelmfileComponentsMap {
 			componentMap := v.(map[interface{}]interface{})
 

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -187,6 +187,19 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 				return nil, err
 			}
 
+			//finalComponentSettings := map[interface{}]interface{}{}
+			//if err := mergo.Merge(&finalComponentSettings, &globalSettings, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTypeCheck); err != nil {
+			//	return nil, err
+			//}
+			//
+			//if err := mergo.Merge(&finalComponentSettings, &terraformSettings, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTypeCheck); err != nil {
+			//	return nil, err
+			//}
+			//
+			//if err := mergo.Merge(&finalComponentSettings, &componentSettings, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTypeCheck); err != nil {
+			//	return nil, err
+			//}
+
 			finalComponentSettings, err := m.Merge([]map[interface{}]interface{}{globalSettings, terraformSettings, componentSettings})
 			if err != nil {
 				return nil, err

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -91,6 +91,21 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 	terraformComponents := map[string]interface{}{}
 	helmfileComponents := map[string]interface{}{}
 	allComponents := map[string]interface{}{}
+	terraformSection := map[interface{}]interface{}{}
+	helmfileSection := map[interface{}]interface{}{}
+	componentsSection := map[interface{}]interface{}{}
+
+	if i, ok := config["terraform"]; ok {
+		terraformSection = i.(map[interface{}]interface{})
+	}
+
+	if i, ok := config["helmfile"]; ok {
+		helmfileSection = i.(map[interface{}]interface{})
+	}
+
+	if i, ok := config["components"]; ok {
+		componentsSection = i.(map[interface{}]interface{})
+	}
 
 	if i, ok := config["vars"]; ok {
 		globalVars = i.(map[interface{}]interface{})
@@ -100,33 +115,33 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 		globalSettings = i.(map[interface{}]interface{})
 	}
 
-	if i, ok := config["terraform"].(map[interface{}]interface{})["vars"]; ok {
+	if i, ok := terraformSection["vars"]; ok {
 		terraformVars = i.(map[interface{}]interface{})
 	}
 
-	if i, ok := config["terraform"].(map[interface{}]interface{})["settings"]; ok {
+	if i, ok := terraformSection["settings"]; ok {
 		terraformSettings = i.(map[interface{}]interface{})
 	}
 
-	if i, ok := config["terraform"].(map[interface{}]interface{})["backend_type"]; ok {
+	if i, ok := terraformSection["backend_type"]; ok {
 		backendType = i.(string)
 	}
 
-	if i, ok := config["terraform"].(map[interface{}]interface{})["backend"]; ok {
+	if i, ok := terraformSection["backend"]; ok {
 		if backendSection, backendSectionExist := i.(map[interface{}]interface{})[backendType]; backendSectionExist {
 			backend = backendSection.(map[interface{}]interface{})
 		}
 	}
 
-	if i, ok := config["helmfile"].(map[interface{}]interface{})["vars"]; ok {
+	if i, ok := helmfileSection["vars"]; ok {
 		helmfileVars = i.(map[interface{}]interface{})
 	}
 
-	if i, ok := config["helmfile"].(map[interface{}]interface{})["settings"]; ok {
+	if i, ok := helmfileSection["settings"]; ok {
 		helmfileSettings = i.(map[interface{}]interface{})
 	}
 
-	if allTerraformComponents, ok := config["components"].(map[interface{}]interface{})["terraform"]; ok {
+	if allTerraformComponents, ok := componentsSection["terraform"]; ok {
 		allTerraformComponentsMap := allTerraformComponents.(map[interface{}]interface{})
 
 		for component, v := range allTerraformComponentsMap {
@@ -196,7 +211,7 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 		}
 	}
 
-	if allHelmfileComponents, ok := config["components"].(map[interface{}]interface{})["helmfile"]; ok {
+	if allHelmfileComponents, ok := componentsSection["helmfile"]; ok {
 		allHelmfileComponentsMap := allHelmfileComponents.(map[interface{}]interface{})
 
 		for component, v := range allHelmfileComponentsMap {

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -108,20 +108,22 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 		terraformSettings = i.(map[interface{}]interface{})
 	}
 
+	if i, ok := config["terraform"].(map[interface{}]interface{})["backend_type"]; ok {
+		backendType = i.(string)
+	}
+
+	if i, ok := config["terraform"].(map[interface{}]interface{})["backend"]; ok {
+		if backendSection, backendSectionExist := i.(map[interface{}]interface{})[backendType]; backendSectionExist {
+			backend = backendSection.(map[interface{}]interface{})
+		}
+	}
+
 	if i, ok := config["helmfile"].(map[interface{}]interface{})["vars"]; ok {
 		helmfileVars = i.(map[interface{}]interface{})
 	}
 
 	if i, ok := config["helmfile"].(map[interface{}]interface{})["settings"]; ok {
 		helmfileSettings = i.(map[interface{}]interface{})
-	}
-
-	if i, ok := config["terraform"].(map[interface{}]interface{})["backend_type"]; ok {
-		backendType = i.(string)
-	}
-
-	if i, ok := config["terraform"].(map[interface{}]interface{})["backend"].(map[interface{}]interface{})[backendType]; ok {
-		backend = i.(map[interface{}]interface{})
 	}
 
 	if allTerraformComponents, ok := config["components"].(map[interface{}]interface{})["terraform"].(map[interface{}]interface{}); ok {
@@ -153,7 +155,10 @@ func ProcessConfig(stack string, config map[interface{}]interface{}) (map[interf
 				if baseComponentSection, baseComponentSectionExist := allTerraformComponents[baseComponentName]; baseComponentSectionExist {
 					baseComponentMap := baseComponentSection.(map[interface{}]interface{})
 					baseComponentVars = baseComponentMap["vars"].(map[interface{}]interface{})
-					baseComponentBackend = baseComponentMap["backend"].(map[interface{}]interface{})[backendType].(map[interface{}]interface{})
+
+					if baseComponentBackendSection, baseComponentBackendSectionExist := baseComponentMap["backend"]; baseComponentBackendSectionExist {
+						baseComponentBackend = baseComponentBackendSection.(map[interface{}]interface{})[backendType].(map[interface{}]interface{})
+					}
 				} else {
 					return nil, errors.New("Terraform component '" + component.(string) + "' defines attribute 'component: " +
 						baseComponentName + "', " + "but `" + baseComponentName + "' is not defined in the stack '" + stack + "'")

--- a/internal/stack/stack_processor_test.go
+++ b/internal/stack/stack_processor_test.go
@@ -1,0 +1,17 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStackProcessor(t *testing.T) {
+	filePaths := []string{
+		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-test.yaml",
+	}
+
+	result, err := ProcessYAMLConfigFiles(filePaths)
+	assert.Nil(t, err)
+	t.Log(result)
+}

--- a/internal/stack/stack_processor_test.go
+++ b/internal/stack/stack_processor_test.go
@@ -1,9 +1,11 @@
 package stack
 
 import (
+	c "github.com/cloudposse/terraform-provider-utils/internal/convert"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 )
 
 func TestStackProcessor(t *testing.T) {
@@ -11,7 +13,15 @@ func TestStackProcessor(t *testing.T) {
 		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-test.yaml",
 	}
 
-	result, err := ProcessYAMLConfigFiles(filePaths)
+	yamlResult, err := ProcessYAMLConfigFiles(filePaths)
 	assert.Nil(t, err)
-	t.Log(result)
+	assert.Equal(t, len(yamlResult), 1)
+
+	mapResult, err := c.YAMLToMapOfInterfaces(yamlResult[0])
+	assert.Nil(t, err)
+
+	yamlConfig, err := yaml.Marshal(mapResult)
+	assert.Nil(t, err)
+
+	t.Log(string(yamlConfig))
 }

--- a/internal/stack/stack_processor_test.go
+++ b/internal/stack/stack_processor_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 )
 
 func TestStackProcessor(t *testing.T) {
 	filePaths := []string{
-		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-test.yaml",
+		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml",
 	}
 
 	yamlResult, err := ProcessYAMLConfigFiles(filePaths)
@@ -20,8 +19,33 @@ func TestStackProcessor(t *testing.T) {
 	mapResult, err := c.YAMLToMapOfInterfaces(yamlResult[0])
 	assert.Nil(t, err)
 
-	yamlConfig, err := yaml.Marshal(mapResult)
-	assert.Nil(t, err)
+	terraformComponents := mapResult["components"].(map[interface{}]interface{})["terraform"].(map[interface{}]interface{})
+	helmfileComponents := mapResult["components"].(map[interface{}]interface{})["helmfile"].(map[interface{}]interface{})
 
-	t.Log(string(yamlConfig))
+	auroraPostgres2Component := terraformComponents["aurora-postgres-2"].(map[interface{}]interface{})
+	assert.Equal(t, auroraPostgres2Component["component"], "aurora-postgres")
+	assert.Equal(t, auroraPostgres2Component["settings"].(map[interface{}]interface{})["spacelift"].(map[interface{}]interface{})["branch"], "dev")
+	assert.Equal(t, auroraPostgres2Component["vars"].(map[interface{}]interface{})["instance_type"], "db.r4.xlarge")
+
+	eksComponent := terraformComponents["eks"].(map[interface{}]interface{})
+	assert.Equal(t, eksComponent["settings"].(map[interface{}]interface{})["spacelift"].(map[interface{}]interface{})["workspace_enabled"], true)
+	assert.Equal(t, eksComponent["settings"].(map[interface{}]interface{})["spacelift"].(map[interface{}]interface{})["branch"], "test")
+	assert.Equal(t, eksComponent["vars"].(map[interface{}]interface{})["spotinst_oceans"].(map[interface{}]interface{})["main"].(map[interface{}]interface{})["max_group_size"], 3)
+	assert.Equal(t, eksComponent["vars"].(map[interface{}]interface{})["spotinst_instance_profile"], "eg-gbl-dev-spotinst-worker")
+
+	accountComponent := terraformComponents["account"].(map[interface{}]interface{})
+	assert.Equal(t, accountComponent["backend_type"], "s3")
+	assert.Equal(t, accountComponent["backend"].(map[interface{}]interface{})["workspace_key_prefix"], "account")
+	assert.Equal(t, accountComponent["backend"].(map[interface{}]interface{})["bucket"], "eg-uw2-root-tfstate")
+	assert.Nil(t, accountComponent["backend"].(map[interface{}]interface{})["role_arn"])
+
+	datadogHelmfileComponent := helmfileComponents["datadog"].(map[interface{}]interface{})
+	assert.Equal(t, datadogHelmfileComponent["vars"].(map[interface{}]interface{})["account_number"], "1234567890")
+	assert.Equal(t, datadogHelmfileComponent["vars"].(map[interface{}]interface{})["installed"], true)
+	assert.Equal(t, datadogHelmfileComponent["vars"].(map[interface{}]interface{})["stage"], "dev")
+	assert.Equal(t, datadogHelmfileComponent["vars"].(map[interface{}]interface{})["processAgent"].(map[interface{}]interface{})["enabled"], true)
+
+	//yamlConfig, err := yaml.Marshal(mapResult)
+	//assert.Nil(t, err)
+	//t.Log(string(yamlConfig))
 }

--- a/internal/stack/stack_processor_test.go
+++ b/internal/stack/stack_processor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 )
 
 func TestStackProcessor(t *testing.T) {
@@ -26,15 +27,29 @@ func TestStackProcessor(t *testing.T) {
 	assert.Equal(t, auroraPostgres2Component["component"], "aurora-postgres")
 	assert.Equal(t, auroraPostgres2Component["settings"].(map[interface{}]interface{})["spacelift"].(map[interface{}]interface{})["branch"], "dev")
 	assert.Equal(t, auroraPostgres2Component["vars"].(map[interface{}]interface{})["instance_type"], "db.r4.xlarge")
+	assert.Equal(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_1"].(string), "test1_override2")
+	assert.Equal(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_2"].(string), "test2_override2")
+	assert.Equal(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_3"].(string), "test3")
+	assert.Equal(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_4"].(string), "test4")
+	assert.Equal(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_5"].(string), "test5")
+	assert.Equal(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_6"].(string), "test6")
+	assert.Equal(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_7"].(string), "test7")
+	assert.Equal(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_8"].(string), "test8")
+	assert.Nil(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_9"])
 
 	eksComponent := terraformComponents["eks"].(map[interface{}]interface{})
 	assert.Equal(t, eksComponent["settings"].(map[interface{}]interface{})["spacelift"].(map[interface{}]interface{})["workspace_enabled"], true)
 	assert.Equal(t, eksComponent["settings"].(map[interface{}]interface{})["spacelift"].(map[interface{}]interface{})["branch"], "test")
 	assert.Equal(t, eksComponent["vars"].(map[interface{}]interface{})["spotinst_oceans"].(map[interface{}]interface{})["main"].(map[interface{}]interface{})["max_group_size"], 3)
 	assert.Equal(t, eksComponent["vars"].(map[interface{}]interface{})["spotinst_instance_profile"], "eg-gbl-dev-spotinst-worker")
+	assert.Equal(t, eksComponent["env"].(map[interface{}]interface{})["ENV_TEST_1"].(string), "test1_override")
+	assert.Equal(t, eksComponent["env"].(map[interface{}]interface{})["ENV_TEST_2"].(string), "test2_override")
+	assert.Equal(t, eksComponent["env"].(map[interface{}]interface{})["ENV_TEST_3"].(string), "test3")
+	assert.Equal(t, eksComponent["env"].(map[interface{}]interface{})["ENV_TEST_4"].(string), "test4")
+	assert.Nil(t, eksComponent["env"].(map[interface{}]interface{})["ENV_TEST_5"])
 
 	accountComponent := terraformComponents["account"].(map[interface{}]interface{})
-	assert.Equal(t, accountComponent["backend_type"], "s3")
+	assert.Equal(t, accountComponent["backend_type"].(string), "s3")
 	assert.Equal(t, accountComponent["backend"].(map[interface{}]interface{})["workspace_key_prefix"], "account")
 	assert.Equal(t, accountComponent["backend"].(map[interface{}]interface{})["bucket"], "eg-uw2-root-tfstate")
 	assert.Nil(t, accountComponent["backend"].(map[interface{}]interface{})["role_arn"])
@@ -45,7 +60,7 @@ func TestStackProcessor(t *testing.T) {
 	assert.Equal(t, datadogHelmfileComponent["vars"].(map[interface{}]interface{})["stage"], "dev")
 	assert.Equal(t, datadogHelmfileComponent["vars"].(map[interface{}]interface{})["processAgent"].(map[interface{}]interface{})["enabled"], true)
 
-	//yamlConfig, err := yaml.Marshal(mapResult)
-	//assert.Nil(t, err)
-	//t.Log(string(yamlConfig))
+	yamlConfig, err := yaml.Marshal(mapResult)
+	assert.Nil(t, err)
+	t.Log(string(yamlConfig))
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	version = "0.2.0"
+	version = "dev"
 )
 
 func main() {


### PR DESCRIPTION
## what
* Add `settings` sections to `data_source_stack_config_yaml` data source to provide settings for Terraform and helmfile components

* Add `env` sections to `data_source_stack_config_yaml` data source to provide ENV vars for Terraform and helmfile components

* Workaround for a deep-merge bug in `mergo.Merge()`

* Fix failing tests

* Add `stack_processor_test.go`

## why
* `settings` sections are deep-merged and used for consumption by external services (e.g. for Spacelift and Terraform Cloud Terraform modules)
*  `env` sections are deep-merged and used to specify ENV vars for consumption by external services (e.g. for Spacelift and Terraform Cloud)
* Workaround for a deep-merge bug in `mergo.Merge()`. When deep-merging slice of maps in a `for` loop, 
  `mergo` modifies the source of the previous loop iteration if it's a complex map and `mergo` gets a pointer to it, 
  not only the destination of the current loop iteration.
* `stack_processor_test.go` to test the provider outputs using a YAML stack config

## test

Given this config:

```
terraform:
  vars: {}
  settings:
    spacelift:
      workspace_enabled: false
      autodeploy: false
  env:
    ENV_TEST_1: test1
    ENV_TEST_2: test2
    ENV_TEST_3: test3
```

```
    aurora-postgres:
      vars:
        instance_type: db.r4.large
        cluster_size: 1
      env:
        ENV_TEST_4: test4
        ENV_TEST_5: test5
        ENV_TEST_6: test6
        ENV_TEST_7: test7

    aurora-postgres-2:
      component: aurora-postgres
      vars:
        instance_type: db.r4.xlarge
      settings:
        spacelift:
          workspace_enabled: true
          autodeploy: true
          branch: "dev"
          triggers: []
      env:
        ENV_TEST_1: test1_override2
        ENV_TEST_2: test2_override2
        ENV_TEST_8: test8

    eks:
      vars:
        spotinst_instance_profile: eg-gbl-dev-spotinst-worker
        spotinst_oceans:
          main:
            desired_group_size: 1
            max_group_size: 3
            min_group_size: 1
            kubernetes_version: null
            ami_release_version: null
            attributes: null
            disk_size: 100
            instance_types: null
            ami_type: "AL2_x86_64"
            tags: null
      settings:
        spacelift:
          workspace_enabled: true
          autodeploy: true
          branch: "test"
          triggers: []
      env:
        ENV_TEST_1: test1_override
        ENV_TEST_2: test2_override
        ENV_TEST_4: test4

```

it produces the following outputs:

```
uw2_uat_aurora_postgres_2_settings = {
  "spacelift" = {
    "autodeploy" = true
    "branch" = "dev"
     "triggers" =  []
    "workspace_enabled" = true
  }
}

uw2_dev_aurora_postgres_2_env = {
  "ENV_TEST_1" = "test1_override2"
  "ENV_TEST_2" = "test2_override2"
  "ENV_TEST_3" = "test3"
  "ENV_TEST_4" = "test4"
  "ENV_TEST_5" = "test5"
  "ENV_TEST_6" = "test6"
  "ENV_TEST_7" = "test7"
  "ENV_TEST_8" = "test8"
}

uw2_uat_aurora_postgres_settings = {
  "spacelift" = {
    "autodeploy" = false
    "workspace_enabled" = false
  }
}

uw2_dev_aurora_postgres_env = {
  "ENV_TEST_1" = "test1"
  "ENV_TEST_2" = "test2"
  "ENV_TEST_3" = "test3"
  "ENV_TEST_4" = "test4"
  "ENV_TEST_5" = "test5"
  "ENV_TEST_6" = "test6"
  "ENV_TEST_7" = "test7"
}

uw2_uat_eks_settings = {
  "spacelift" = {
    "autodeploy" = false
    "branch" = "test"
    "triggers" = []
    "workspace_enabled" = true
  }
}

uw2_dev_eks_env = {
  "ENV_TEST_1" = "test1_override"
  "ENV_TEST_2" = "test2_override"
  "ENV_TEST_3" = "test3"
  "ENV_TEST_4" = "test4"
}

```
