### PR TITLE
Ensure results have unique IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ terraform {
   required_providers {
     utils = {
       source = "cloudposse/utils"
-      version = "0.2.0"
+      version = ">= 0.3.0"
     }
   }
 }

--- a/README.yaml
+++ b/README.yaml
@@ -60,7 +60,7 @@ usage: |-
     required_providers {
       utils = {
         source = "cloudposse/utils"
-        version = "0.2.0"
+        version = ">= 0.3.0"
       }
     }
   }

--- a/internal/convert/id.go
+++ b/internal/convert/id.go
@@ -1,0 +1,14 @@
+package convert
+
+import (
+	"crypto/sha1"
+	"fmt"
+)
+
+var h = sha1.New()
+
+func MakeId(s []byte) string {
+	h.Reset()
+	h.Write(s)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/internal/convert/id.go
+++ b/internal/convert/id.go
@@ -7,6 +7,7 @@ import (
 
 var h = sha1.New()
 
+// MakeId takes a byte representation of a resource and returns a stable string ID for it.
 func MakeId(s []byte) string {
 	h.Reset()
 	h.Write(s)

--- a/internal/provider/data_source_deep_merge_json.go
+++ b/internal/provider/data_source_deep_merge_json.go
@@ -63,7 +63,7 @@ func dataSourceDeepMergeJSONRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	d.SetId("static")
+	d.SetId(c.MakeId(jsonResult))
 
 	return nil
 }

--- a/internal/provider/data_source_deep_merge_yaml.go
+++ b/internal/provider/data_source_deep_merge_yaml.go
@@ -58,7 +58,7 @@ func dataSourceDeepMergeYAMLRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	d.SetId("static")
+	d.SetId(c.MakeId(yamlResult))
 
 	return nil
 }

--- a/internal/provider/data_source_stack_config_yaml.go
+++ b/internal/provider/data_source_stack_config_yaml.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"strings"
+
 	c "github.com/cloudposse/terraform-provider-utils/internal/convert"
 
 	s "github.com/cloudposse/terraform-provider-utils/internal/stack"
@@ -51,7 +53,8 @@ func dataSourceStackConfigYAMLRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	d.SetId("static")
+	id := c.MakeId([]byte(strings.Join(result, "")))
+	d.SetId(id)
 
 	return nil
 }


### PR DESCRIPTION
## what
- Ensure results have unique IDs

## why
- Typically a component will have multiple instances of this module, and to avoid confusion they should have unique ids. 