### PR TITLE
[stack_processor]: Add `process_stack_deps` input var to the `stack_config` data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 -->
 
-Terraform provider to add additional missing functionality to Terraform
+Terraform provider for various utilities (deep merging, stack configuration management), and to add additional missing functionality to Terraform
 
 
 ---

--- a/README.yaml
+++ b/README.yaml
@@ -46,7 +46,7 @@ references:
 
 # Short description of this project
 description: |-
-  Terraform provider to add additional missing functionality to Terraform
+  Terraform provider for various utilities (deep merging, stack configuration management), and to add additional missing functionality to Terraform
 
 #introduction: |-
 #  This is an introduction.

--- a/examples/data-sources/utils_stack_config_yaml/data-source.tf
+++ b/examples/data-sources/utils_stack_config_yaml/data-source.tf
@@ -17,6 +17,8 @@ data "utils_stack_config_yaml" "example" {
     "${path.module}/stacks/uw2-staging.yaml",
     "${path.module}/stacks/uw2-uat.yaml"
   ]
+
+  process_stack_deps = true
 }
 
 locals {

--- a/internal/provider/data_source_stack_config_yaml.go
+++ b/internal/provider/data_source_stack_config_yaml.go
@@ -25,6 +25,12 @@ func dataSourceStackConfigYAML() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Required:    true,
 			},
+			"process_stack_deps": {
+				Description: "A boolean flag to enable/disable processing all stack dependencies for the components.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
 			"output": {
 				Description: "A list of stack configurations.",
 				Type:        schema.TypeList,
@@ -37,13 +43,14 @@ func dataSourceStackConfigYAML() *schema.Resource {
 
 func dataSourceStackConfigYAMLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	input := d.Get("input")
+	processStackDeps := d.Get("process_stack_deps")
 
 	paths, err := c.SliceOfInterfacesToSliceOfStrings(input.([]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	result, err := s.ProcessYAMLConfigFiles(paths)
+	result, err := s.ProcessYAMLConfigFiles(paths, processStackDeps.(bool))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/stack/stack_processor_test.go
+++ b/internal/stack/stack_processor_test.go
@@ -13,7 +13,9 @@ func TestStackProcessor(t *testing.T) {
 		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml",
 	}
 
-	yamlResult, err := ProcessYAMLConfigFiles(filePaths)
+	processStackDeps := true
+
+	var yamlResult, err = ProcessYAMLConfigFiles(filePaths, processStackDeps)
 	assert.Nil(t, err)
 	assert.Equal(t, len(yamlResult), 1)
 
@@ -37,12 +39,15 @@ func TestStackProcessor(t *testing.T) {
 	assert.Equal(t, "test7", auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_7"].(string))
 	assert.Equal(t, "test8", auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_8"].(string))
 	assert.Nil(t, auroraPostgres2Component["env"].(map[interface{}]interface{})["ENV_TEST_9"])
-	assert.Equal(t, "globals", auroraPostgres2Component["stacks"].([]interface{})[0])
-	assert.Equal(t, "uw2-dev", auroraPostgres2Component["stacks"].([]interface{})[1])
-	assert.Equal(t, "uw2-globals", auroraPostgres2Component["stacks"].([]interface{})[2])
-	assert.Equal(t, "uw2-prod", auroraPostgres2Component["stacks"].([]interface{})[3])
-	assert.Equal(t, "uw2-staging", auroraPostgres2Component["stacks"].([]interface{})[4])
-	assert.Equal(t, "uw2-uat", auroraPostgres2Component["stacks"].([]interface{})[5])
+
+	if processStackDeps {
+		assert.Equal(t, "globals", auroraPostgres2Component["stacks"].([]interface{})[0])
+		assert.Equal(t, "uw2-dev", auroraPostgres2Component["stacks"].([]interface{})[1])
+		assert.Equal(t, "uw2-globals", auroraPostgres2Component["stacks"].([]interface{})[2])
+		assert.Equal(t, "uw2-prod", auroraPostgres2Component["stacks"].([]interface{})[3])
+		assert.Equal(t, "uw2-staging", auroraPostgres2Component["stacks"].([]interface{})[4])
+		assert.Equal(t, "uw2-uat", auroraPostgres2Component["stacks"].([]interface{})[5])
+	}
 
 	eksComponent := terraformComponents["eks"].(map[interface{}]interface{})
 	assert.Equal(t, true, eksComponent["settings"].(map[interface{}]interface{})["spacelift"].(map[interface{}]interface{})["workspace_enabled"])


### PR DESCRIPTION
## what
* [stack_processor]: Add `process_stack_deps` input var to the `stack_config` data source

## why
* Make the settings configurable (`false` by default)
* Not all provider invocations need to process all stack dependencies for the components (e.g. Spacelift module needs it, `remote-state` does not)
* Makes invocations without processing stack dependencies 2-3 times faster
