### PR TITLE
Fix target branch of workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,7 @@ name: auto-release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   publish:


### PR DESCRIPTION
## what
- Set `auto-release` to run on push to `main` branch

## why
- Was set to run on push to `master` branch, but this repo does not have a `master` branch, so it never ran