### PR TITLE
Use thread safe function

### DIFF
--- a/internal/convert/id.go
+++ b/internal/convert/id.go
@@ -5,11 +5,7 @@ import (
 	"fmt"
 )
 
-var h = sha1.New()
-
 // MakeId takes a byte representation of a resource and returns a stable string ID for it.
 func MakeId(s []byte) string {
-	h.Reset()
-	h.Write(s)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%x", sha1.Sum(s))
 }


### PR DESCRIPTION
## what
- Use thread safe function to generate object IDs

## why
- Terraform performs actions in parallel, so using a global variable is not safe

```
panic: d.nx != 0
plugin.terraform-provider-utils_v0.4.2: 
plugin.terraform-provider-utils_v0.4.2: goroutine 61 [running]:
plugin.terraform-provider-utils_v0.4.2: crypto/sha1.(*digest).checkSum(0xc000497778, 0x0, 0x0, 0xec943cb500000000)
```
