### PR TITLE
Change go version in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
## what
* Updates github release action to use 1.16

Do the `go.sum` and `go.mod` files also need to be updated ?

## why
* The go releaser worked for me locally because I'm using go 1.16 but did not work in github action as go 1.15 still does not allow darwin arm releases.

## references
* Previous PR https://github.com/cloudposse/terraform-provider-utils/pull/38
* Closes https://github.com/cloudposse/terraform-provider-utils/issues/33
