### PR TITLE
[spacelift_stack_processor]: Update Spacelift labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,10 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
-
-
 
 
 

--- a/internal/spacelift/spacelift_stack_processor.go
+++ b/internal/spacelift/spacelift_stack_processor.go
@@ -139,11 +139,9 @@ func TransformStackConfigToSpaceliftStacks(
 						labels = append(labels, fmt.Sprintf("deps:"+stackConfigPathTemplate, v))
 					}
 					labels = append(labels, fmt.Sprintf("folder:component/%s", component))
+					// Split on the first `-` and get the two parts: environment and stage
 					stackNameParts := strings.SplitN(stackName, "-", 2)
 					stackNamePartsLen := len(stackNameParts)
-					if stackNamePartsLen > 0 {
-						labels = append(labels, fmt.Sprintf("folder:%s", stackNameParts[0]))
-					}
 					if stackNamePartsLen == 2 {
 						labels = append(labels, fmt.Sprintf("folder:%s/%s", stackNameParts[0], stackNameParts[1]))
 					}


### PR DESCRIPTION
## what
* [spacelift_stack_processor]: Update Spacelift labels

## why
* For each component (which is a Spacelift stack), we need to apply only the `folder: env/stage` label. No need for `folder: env` label since if both are applied, Spacelift double-counts components in each folder (and no component exists directly in `env`, they are under `env/stage`)

