### PR TITLE
[spacelift_stack_processor]: Add explicit labels to Spacelift stacks

### DIFF
--- a/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-dev.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-dev.yaml
@@ -76,6 +76,8 @@ components:
           autodeploy: true
           branch: "dev"
           triggers: []
+          labels:
+            - "deps:config/secrets/dev-internal-secrets.yml"
       env:
         ENV_TEST_1: test1_override2
         ENV_TEST_2: test2_override2

--- a/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-prod.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-prod.yaml
@@ -86,6 +86,8 @@ components:
           autodeploy: true
           branch: ""
           triggers: []
+          labels:
+            - "deps:config/secrets/prod-internal-secrets.yml"
       env:
         ENV_TEST_1: test1_override2
         ENV_TEST_2: test2_override2

--- a/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-staging.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-staging.yaml
@@ -86,6 +86,8 @@ components:
           autodeploy: true
           branch: ""
           triggers: []
+          labels:
+            - "deps:config/secrets/staging-internal-secrets.yml"
       env:
         ENV_TEST_1: test1_override2
         ENV_TEST_2: test2_override2

--- a/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-uat.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-uat.yaml
@@ -95,6 +95,8 @@ components:
           autodeploy: true
           branch: "test4"
           triggers: ["7", "8", "9"]
+          labels:
+            - "deps:config/secrets/uat-internal-secrets.yml"
       env:
         ENV_TEST_1: test1_override2
         ENV_TEST_2: test2_override2

--- a/internal/spacelift/spacelift_stack_processor.go
+++ b/internal/spacelift/spacelift_stack_processor.go
@@ -53,18 +53,25 @@ func TransformStackConfigToSpaceliftStacks(
 						componentSettings = i.(map[interface{}]interface{})
 					}
 
+					spaceliftSettings := map[interface{}]interface{}{}
 					spaceliftWorkspaceEnabled := false
+
 					if i, ok2 := componentSettings["spacelift"]; ok2 {
-						spaceliftSettings := i.(map[interface{}]interface{})
+						spaceliftSettings = i.(map[interface{}]interface{})
 
 						if i3, ok3 := spaceliftSettings["workspace_enabled"]; ok3 {
 							spaceliftWorkspaceEnabled = i3.(bool)
 						}
 					}
 
-					// If Spacelift workspace is disabled, don't include it
+					// If Spacelift workspace is disabled, don't include it, continue to the next component
 					if spaceliftWorkspaceEnabled == false {
 						continue
+					}
+
+					spaceliftExplicitLabels := []interface{}{}
+					if i, ok2 := spaceliftSettings["labels"]; ok2 {
+						spaceliftExplicitLabels = i.([]interface{})
 					}
 
 					spaceliftConfig := map[string]interface{}{}
@@ -137,6 +144,9 @@ func TransformStackConfigToSpaceliftStacks(
 					}
 					for _, v := range componentDeps {
 						labels = append(labels, fmt.Sprintf("deps:"+stackConfigPathTemplate, v))
+					}
+					for _, v := range spaceliftExplicitLabels {
+						labels = append(labels, v.(string))
 					}
 					labels = append(labels, fmt.Sprintf("folder:component/%s", component))
 					// Split on the first `-` and get the two parts: environment and stage

--- a/internal/spacelift/spacelift_stack_processor_test.go
+++ b/internal/spacelift/spacelift_stack_processor_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestSpaceliftStackProcessor(t *testing.T) {
 	filePaths := []string{
-		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-dev.yaml",
-		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-prod.yaml",
-		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-staging.yaml",
-		"../../examples/data-sources/utils_stack_config_yaml/stacks/uw2-uat.yaml",
+		"../../examples/data-sources/utils_spacelift_stack_config/stacks/uw2-dev.yaml",
+		"../../examples/data-sources/utils_spacelift_stack_config/stacks/uw2-prod.yaml",
+		"../../examples/data-sources/utils_spacelift_stack_config/stacks/uw2-staging.yaml",
+		"../../examples/data-sources/utils_spacelift_stack_config/stacks/uw2-uat.yaml",
 	}
 
 	processStackDeps := true


### PR DESCRIPTION
## what
* [spacelift_stack_processor]: Add explicit labels to Spacelift stacks defined in YAML configs

## why
* Allow adding custom labels to each stack's Spacelift config
* This will allow 
   - adding explicit dependencies (files) to each stack (if the files change, the stack will be triggered)
   - creating complex workflows where one Spacelift stack depends on others

## test

Given this config with the custom label:

```
aurora-postgres-2:
  settings:
    spacelift:
      workspace_enabled: true
      labels:
        - "deps:config/secrets/dev-internal-secrets.yml"
```

the provider generates the following list of all labels for the component (including the custom label):

```
labels:
  - import:stacks/catalog/eks-defaults.yaml
  - import:stacks/catalog/rds-defaults.yaml
  - import:stacks/catalog/s3-defaults.yaml
  - import:stacks/globals.yaml
  - import:stacks/uw2-globals.yaml
  - stack:stacks/catalog/rds-defaults.yaml
  - stack:stacks/globals.yaml
  - stack:stacks/uw2-dev.yaml
  - stack:stacks/uw2-globals.yaml
  - stack:stacks/uw2-prod.yaml
  - stack:stacks/uw2-staging.yaml
  - stack:stacks/uw2-uat.yaml
  - deps:stacks/catalog/rds-defaults.yaml
  - deps:stacks/globals.yaml
  - deps:stacks/uw2-dev.yaml
  - deps:stacks/uw2-globals.yaml
  - deps:config/secrets/dev-internal-secrets.yml
  - folder:component/aurora-postgres-2
  - folder:uw2/dev
```
