### PR TITLE
[spacelift_stack_processor]: Add `depends-on` to Spacelift YAML stack config

### DIFF
--- a/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-dev.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-dev.yaml
@@ -51,6 +51,8 @@ components:
           autodeploy: true
           branch: "test"
           triggers: []
+          depends-on:
+            - vpc
       env:
         ENV_TEST_1: test1_override
         ENV_TEST_2: test2_override
@@ -78,6 +80,9 @@ components:
           triggers: []
           labels:
             - "deps:config/secrets/dev-internal-secrets.yml"
+          depends-on:
+            - vpc
+            - dns-delegated
       env:
         ENV_TEST_1: test1_override2
         ENV_TEST_2: test2_override2

--- a/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-prod.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-prod.yaml
@@ -88,6 +88,9 @@ components:
           triggers: []
           labels:
             - "deps:config/secrets/prod-internal-secrets.yml"
+          depends-on:
+            - vpc
+            - dns-delegated
       env:
         ENV_TEST_1: test1_override2
         ENV_TEST_2: test2_override2

--- a/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-staging.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-staging.yaml
@@ -88,6 +88,9 @@ components:
           triggers: []
           labels:
             - "deps:config/secrets/staging-internal-secrets.yml"
+          depends-on:
+            - vpc
+            - dns-delegated
       env:
         ENV_TEST_1: test1_override2
         ENV_TEST_2: test2_override2

--- a/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-uat.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/uw2-uat.yaml
@@ -97,6 +97,9 @@ components:
           triggers: ["7", "8", "9"]
           labels:
             - "deps:config/secrets/uat-internal-secrets.yml"
+          depends-on:
+            - vpc
+            - dns-delegated
       env:
         ENV_TEST_1: test1_override2
         ENV_TEST_2: test2_override2

--- a/internal/spacelift/spacelift_stack_processor.go
+++ b/internal/spacelift/spacelift_stack_processor.go
@@ -74,6 +74,11 @@ func TransformStackConfigToSpaceliftStacks(
 						spaceliftExplicitLabels = i.([]interface{})
 					}
 
+					spaceliftDependsOn := []interface{}{}
+					if i, ok2 := spaceliftSettings["depends-on"]; ok2 {
+						spaceliftDependsOn = i.([]interface{})
+					}
+
 					spaceliftConfig := map[string]interface{}{}
 					spaceliftConfig["enabled"] = spaceliftWorkspaceEnabled
 
@@ -147,6 +152,9 @@ func TransformStackConfigToSpaceliftStacks(
 					}
 					for _, v := range spaceliftExplicitLabels {
 						labels = append(labels, v.(string))
+					}
+					for _, v := range spaceliftDependsOn {
+						labels = append(labels, fmt.Sprintf("depends-on:%s-%s", stackName, v))
 					}
 					labels = append(labels, fmt.Sprintf("folder:component/%s", component))
 					// Split on the first `-` and get the two parts: environment and stage


### PR DESCRIPTION
## what
* [spacelift_stack_processor]: Add `depends-on` to Spacelift YAML stack config

## why
* For each stack, allow specifying its dependencies on other stacks in YAML stack config
* `depends-on` then added to `labels` for the Spacelift stacks
* Will be used in Spacelift workflows (using Rego policies) to trigger the dependent stacks after the "parent" stacks finish running

## test

```
    aurora-postgres-2:
      component: aurora-postgres
      settings:
        spacelift:
          workspace_enabled: true
          autodeploy: true
          labels:
            - "deps:config/secrets/dev-internal-secrets.yml"
          depends-on:
            - vpc
            - dns-delegated
```

```
labels:
    - deps:stacks/catalog/rds-defaults.yaml
    - deps:stacks/globals.yaml
    - deps:stacks/uw2-dev.yaml
    - deps:stacks/uw2-globals.yaml
    - deps:config/secrets/dev-internal-secrets.yml
    - depends-on:uw2-dev-vpc
    - depends-on:uw2-dev-dns-delegated
    - folder:component/aurora-postgres-2
    - folder:uw2/dev
```

