### PR TITLE
Fix YAML conversion with empty strings

### DIFF
--- a/internal/convert/yaml.go
+++ b/internal/convert/yaml.go
@@ -20,15 +20,12 @@ func YAMLSliceOfInterfaceToSliceOfMaps(input []interface{}) ([]map[interface{}]i
 	output := make([]map[interface{}]interface{}, 0)
 	for _, current := range input {
 		// Apply YAMLToMap only if string is passed
-		switch c := current.(type) {
-			case string:
-				data, err := YAMLToMapOfInterfaces(c)
-				if err != nil {
-					return nil, err
-				}
-				output = append(output, data)
-			default:
-				continue
+		if currentYaml, ok := current.(string); ok {
+			data, err := YAMLToMapOfInterfaces(currentYaml)
+			if err != nil {
+				return nil, err
+			}
+			output = append(output, data)
 		}
 	}
 	return output, nil

--- a/internal/convert/yaml.go
+++ b/internal/convert/yaml.go
@@ -1,6 +1,8 @@
 package convert
 
-import "gopkg.in/yaml.v2"
+import (
+	"gopkg.in/yaml.v2"
+)
 
 // YAMLToMapOfInterfaces takes a YAML string as input and returns a map[interface{}]interface{}
 func YAMLToMapOfInterfaces(input string) (map[interface{}]interface{}, error) {
@@ -17,11 +19,17 @@ func YAMLToMapOfInterfaces(input string) (map[interface{}]interface{}, error) {
 func YAMLSliceOfInterfaceToSliceOfMaps(input []interface{}) ([]map[interface{}]interface{}, error) {
 	output := make([]map[interface{}]interface{}, 0)
 	for _, current := range input {
-		data, err := YAMLToMapOfInterfaces(current.(string))
-		if err != nil {
-			return nil, err
+		// Apply YAMLToMap only if string is passed
+		switch c := current.(type) {
+			case string:
+				data, err := YAMLToMapOfInterfaces(c)
+				if err != nil {
+					return nil, err
+				}
+				output = append(output, data)
+			default:
+				continue
 		}
-		output = append(output, data)
 	}
 	return output, nil
 }


### PR DESCRIPTION
## YAML merge fails when the input variable is an empty string or nil. 

Hey, thanks for this provider. We use it to do a merge of two Helm value files (example below) - one with a set of default values and one with user overrides/additions. In cases when user does not set any overriding values, the second input is empty (`var.values`).

Passing an empty string (or nil) to the inputs, causes the provider to crash. I'm attaching the panic log below.

```
data "utils_deep_merge_yaml" "values" {
  count = var.enabled ? 1 : 0
  input = [
    local.values,
    var.values
  ]
}
```

```
goroutine 34 [running]:
github.com/cloudposse/terraform-provider-utils/internal/convert.YAMLSliceOfInterfaceToSliceOfMaps(0xc000576660, 0x2, 0x2, 0xb49b80, 0xc000338408, 0xd4ad01, 0xc00033a7c0, 0xc03b6ee8763240ae)
        github.com/cloudposse/terraform-provider-utils/internal/convert/yaml.go:20 +0x1f4
github.com/cloudposse/terraform-provider-utils/internal/provider.dataSourceDeepMergeYAMLRead(0xd4ada8, 0xc0003346c0, 0xc000366300, 0x0, 0x0, 0xc000336a70, 0xc000375948, 0x40e0f8)
        github.com/cloudposse/terraform-provider-utils/internal/provider/data_source_deep_merge_yaml.go:40 +0x87
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc0003dc0e0, 0xd4ad38, 0xc00033a7c0, 0xc000366300, 0x0, 0x0, 0x0, 0x0, 0x0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:347 +0x17f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc0003dc0e0, 0xd4ad38, 0xc00033a7c0, 0xc000576300, 0x0, 0x0, 0x0, 0xc000576300, 0x0, 0x0)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:558 +0xfd
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc00000c0a8, 0xd4ad38, 0xc00033a7c0, 0xc000576140, 0xc00033a7c0, 0x40b965, 0xbfbf20)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/grpc_provider.go:1105 +0x4d6
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadDataSource(0xc0000b9ac0, 0xd4ade0, 0xc00033a7c0, 0xc0003480a0, 0xc0000b9ac0, 0xc0003461b0, 0xc00058aba0)
        github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:247 +0xe5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler(0xc28bc0, 0xc0000b9ac0, 0xd4ade0, 0xc0003461b0, 0xc0003344e0, 0x0, 0xd4ade0, 0xc0003461b0, 0xc000360300, 0x17a)
        github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:416 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00025ae00, 0xd51b58, 0xc000131980, 0xc000352000, 0xc0002c67b0, 0x11576d0, 0x0, 0x0, 0x0)
        google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00025ae00, 0xd51b58, 0xc000131980, 0xc000352000, 0x0)
        google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc000116280, 0xc00025ae00, 0xd51b58, 0xc000131980, 0xc000352000)
        google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd

Error: The terraform-provider-utils_v0.12.0 plugin crashed!
```

This PR adds a switch to the YAML convert function, which asses the interface type before passing the input to the convert function. In case a non-string value is passed as input, the iteration in the inner loop is skipped.

TL;DR
* provider crashed when empty string is passed as input
* PR adds type assessment and accepts only string values

