### PR TITLE
[stack_processor]: Fix imports. Fix deadlocks. Add validation. Improve error messages

### DIFF
--- a/examples/data-sources/utils_spacelift_stack_config/stacks/catalog/eks-app-defaults.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/catalog/eks-app-defaults.yaml
@@ -1,5 +1,5 @@
 import:
-   - services/*
+   - catalog/services/*
 
 components:
   terraform:

--- a/examples/data-sources/utils_spacelift_stack_config/stacks/catalog/eks-defaults.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/stacks/catalog/eks-defaults.yaml
@@ -1,5 +1,5 @@
 import:
-  - eks-app-defaults
+  - catalog/eks-app-defaults
 
 components:
   terraform:

--- a/examples/data-sources/utils_stack_config_yaml/stacks/catalog/eks-app-defaults.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/catalog/eks-app-defaults.yaml
@@ -1,5 +1,5 @@
 import:
-   - services/*.yaml
+   - catalog/services/*.yaml
 
 components:
   terraform:

--- a/examples/data-sources/utils_stack_config_yaml/stacks/catalog/eks-defaults.yaml
+++ b/examples/data-sources/utils_stack_config_yaml/stacks/catalog/eks-defaults.yaml
@@ -1,5 +1,5 @@
 import:
-  - eks-app-defaults
+  - catalog/eks-app-defaults
 
 components:
   terraform:

--- a/internal/stack/stack_processor.go
+++ b/internal/stack/stack_processor.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"fmt"
 	c "github.com/cloudposse/terraform-provider-utils/internal/convert"
 	m "github.com/cloudposse/terraform-provider-utils/internal/merge"
 	u "github.com/cloudposse/terraform-provider-utils/internal/utils"
@@ -101,7 +102,6 @@ func ProcessYAMLConfigFile(
 	importsConfig map[string]map[interface{}]interface{}) (map[interface{}]interface{}, map[string]map[interface{}]interface{}, error) {
 
 	var configs []map[interface{}]interface{}
-	dir := path.Dir(filePath)
 
 	stackYamlConfig, err := ioutil.ReadFile(filePath)
 	if err != nil {
@@ -125,7 +125,7 @@ func ProcessYAMLConfigFile(
 		for _, im := range imports {
 			imp := im.(string)
 
-			// If the import file is specified without extension, add `.yaml` as default
+			// If the import file is specified without extension, use `.yaml` as default
 			impWithExt := imp
 			ext := filepath.Ext(imp)
 			if ext == "" {
@@ -133,35 +133,50 @@ func ProcessYAMLConfigFile(
 				impWithExt = imp + ext
 			}
 
+			impWithExtPath := path.Join(basePath, impWithExt)
+
+			if impWithExtPath == filePath {
+				errorMessage := fmt.Sprintf("Invalid import in config file %s. The file imports itself in import: '%s'",
+					filePath,
+					strings.Replace(impWithExt, basePath+"/", "", 1))
+				return nil, nil, errors.New(errorMessage)
+			}
+
 			// Find all matches in the glob
-			impWithExtPath := path.Join(dir, impWithExt)
 			matches, err := filepath.Glob(impWithExtPath)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			// If we import a glob with more than 1 file, add the difference to the WaitGroup
-			if len(matches) > 1 {
-				wg.Add(len(matches) - 1)
-			}
+			if matches != nil {
+				// If we import a glob with more than 1 file, add the difference to the WaitGroup
+				if len(matches) > 1 {
+					wg.Add(len(matches) - 1)
+				}
 
-			for _, importFile := range matches {
-				go func(p string) {
-					defer wg.Done()
+				for _, importFile := range matches {
+					go func(p string) {
+						defer wg.Done()
 
-					yamlConfig, _, err := ProcessYAMLConfigFile(basePath, p, importsConfig)
-					if err != nil {
-						errorResult = err
-						return
-					}
+						yamlConfig, _, err := ProcessYAMLConfigFile(basePath, p, importsConfig)
+						if err != nil {
+							errorResult = err
+							return
+						}
 
-					processYAMLConfigFileLock.Lock()
-					defer processYAMLConfigFileLock.Unlock()
-					configs = append(configs, yamlConfig)
-					importRelativePathWithExt := strings.Replace(p, basePath+"/", "", 1)
-					importRelativePathWithoutExt := strings.Replace(importRelativePathWithExt, ext, "", 1)
-					importsConfig[importRelativePathWithoutExt] = yamlConfig
-				}(importFile)
+						processYAMLConfigFileLock.Lock()
+						defer processYAMLConfigFileLock.Unlock()
+						configs = append(configs, yamlConfig)
+						importRelativePathWithExt := strings.Replace(p, basePath+"/", "", 1)
+						importRelativePathWithoutExt := strings.Replace(importRelativePathWithExt, ext, "", 1)
+						importsConfig[importRelativePathWithoutExt] = yamlConfig
+					}(importFile)
+				}
+			} else {
+				errorMessage := fmt.Sprintf("Invalid import in config file %s. No matches found for import: '%s'",
+					filePath,
+					strings.Replace(impWithExt, basePath+"/", "", 1))
+				return nil, nil, errors.New(errorMessage)
 			}
 		}
 


### PR DESCRIPTION
## what
* Fix imports
* Fix deadlocks
* Add validation
* Improve error messages

## why
* Use absolute import paths (from the base path, which is usually `stacks`) even inside subfolders. 
It's more clear to use 
```  
import:
  - catalog/services/*.yaml
```

than
```
import:
  - services/*.yaml
```

if `/services/*.yaml` is a subfolder of `catalog`.


   
* Fix deadlock - if any import pointed to an incorrect path, the `WaitGroup` was waiting forever causing process hang/freeze. Now it checks if the import path exists and points to any files, and throws an error otherwise

* Add validation and improve error messages for situations like these:

```
Invalid import in config file ../stacks/catalog/eks-app-defaults.yaml. 
No config files found for import: catalog/services/s1/*.yaml

Invalid import in config file ../stacks/uw2-globals.yaml. 
No matches found for import: 'globals2.yaml'
```

```
Invalid import in config file ../stacks/uw2-globals.yaml. 
The file imports itself in import: 'uw2-globals.yaml'

```
