### PR TITLE
Bump `atmos` version. Update tests

### DIFF
--- a/examples/complete/stacks/catalog/terraform/test-component-override.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component-override.yaml
@@ -16,6 +16,10 @@ components:
       component: "test/test-component"
       # Other variables can be overridden here
       vars: {}
+      env:
+        TEST_ENV_VAR1: "val1-override"
+        TEST_ENV_VAR3: "val3-override"
+        TEST_ENV_VAR4: "val4"
       # Override remote state backend for this component
       remote_state_backend_type: static # s3, remote, vault, static, etc.
       remote_state_backend:

--- a/examples/complete/stacks/catalog/terraform/test-component.yaml
+++ b/examples/complete/stacks/catalog/terraform/test-component.yaml
@@ -9,11 +9,12 @@ import:
 components:
   terraform:
     "test/test-component":
-      backend:
-        s3:
-          workspace_key_prefix: test-test-component
       settings:
         spacelift:
           workspace_enabled: true
       vars:
         enabled: true
+      env:
+        TEST_ENV_VAR1: "val1"
+        TEST_ENV_VAR2: "val2"
+        TEST_ENV_VAR3: "val3"

--- a/examples/complete/stacks/catalog/terraform/top-level-component1.yaml
+++ b/examples/complete/stacks/catalog/terraform/top-level-component1.yaml
@@ -9,9 +9,6 @@ import:
 components:
   terraform:
     top-level-component1:
-      backend:
-        s3:
-          workspace_key_prefix: top-level-component1
       settings:
         spacelift:
           workspace_enabled: true

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudposse/terraform-provider-utils
 go 1.16
 
 require (
-	github.com/cloudposse/atmos v1.3.7
+	github.com/cloudposse/atmos v1.3.8
 	github.com/gruntwork-io/terratest v0.38.2
 	github.com/hashicorp/terraform-plugin-docs v0.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudposse/atmos v1.3.7 h1:mTLs/sQsaAYmhtTxmnbGLDlriVkVFcD0CCtQnkc72JU=
-github.com/cloudposse/atmos v1.3.7/go.mod h1:HK5MGGjlAoaethJL52KIjM164xONsoF81KCLON+zvg0=
+github.com/cloudposse/atmos v1.3.8 h1:vPs0DtEhx0z7O3S2XcDC1ndVlM0MleFaxkCUNrjWbmU=
+github.com/cloudposse/atmos v1.3.8/go.mod h1:HK5MGGjlAoaethJL52KIjM164xONsoF81KCLON+zvg0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/internal/stack/stack_processor_test.go
+++ b/internal/stack/stack_processor_test.go
@@ -114,6 +114,14 @@ func TestStackProcessor(t *testing.T) {
 	assert.Equal(t, 3, testTestComponentOverrideComponentRemoteStateBackendVal3)
 	assert.Equal(t, nil, testTestComponentOverrideComponentRemoteStateBackendVal4)
 
+	topLevelComponent1 := terraformComponents["top-level-component1"].(map[interface{}]interface{})
+	topLevelComponent1Backend := topLevelComponent1["backend"].(map[interface{}]interface{})
+	topLevelComponent1RemoteSateBackend := topLevelComponent1["remote_state_backend"].(map[interface{}]interface{})
+	topLevelComponent1BackendWorkspaceKeyPrefix := topLevelComponent1Backend["workspace_key_prefix"]
+	topLevelComponent1RemoteStateBackendWorkspaceKeyPrefix := topLevelComponent1RemoteSateBackend["workspace_key_prefix"]
+	assert.Equal(t, "top-level-component1", topLevelComponent1BackendWorkspaceKeyPrefix)
+	assert.Equal(t, "top-level-component1", topLevelComponent1RemoteStateBackendWorkspaceKeyPrefix)
+
 	yamlConfig, err := yaml.Marshal(mapConfig1)
 	assert.Nil(t, err)
 	t.Log(string(yamlConfig))


### PR DESCRIPTION
## what
* Bump `atmos` version
* Detect ENV vars in YAML stack config and set them for command execution
* Make `workspace_key_prefix` config DRY
* Update tests
* General cleanup

## why
* Detect ENV vars in YAML stack config and set them for command execution - allow specifying ENV vars in YAML config files. For each component in a stack, ENV vars are deep-merged in this order: global ENV vars, terraform section ENV vars, base component ENV vars, component ENV vars. The when commands are executed, print the final set of ENV vars and set them in the executing shell. This will allow controlling the tools behavior (e.g. Terraform, helmfile) by YAML configs

```
Command info:
Terraform binary: /usr/local/bin/terraform
Terraform command: plan
Arguments and flags: []
Component: test/test-component-override
Base component: test/test-component
Stack: tenant1/ue2/dev
Working dir: ./examples/complete/components/terraform/test/test-component

Using ENV vars:
TEST_ENV_VAR3=val3-override
TEST_ENV_VAR1=val1-override
TEST_ENV_VAR2=val2
TEST_ENV_VAR4=val4

Executing command:
/usr/local/bin/terraform workspace select tenant1-ue2-dev-test-component-override

Executing command:
/usr/local/bin/terraform plan -var-file tenant1-ue2-dev-test-component-override.terraform.tfvars.json -out tenant1-ue2-dev-test-component-override.planfile
```

* Check if `backend` section has `workspace_key_prefix` for `s3` backend type. If it does not, use the component name instead. It also propagates to `remote_state_backend` section of `s3` type. This will allow to have components catalog files DRY without repeating the same config (which now can be generated automatically by the component names). Components folders are supported and taken into account in the generated `workspace_key_prefix`. This can be overridden as before per component.

This config 

```
components:
  terraform:
    "test/test-component":
      backend:
        s3:
          workspace_key_prefix: test-test-component
      settings:
        spacelift:
          workspace_enabled: true
```

is now the same as this 

```
components:
  terraform:
    "test/test-component":
      settings:
        spacelift:
          workspace_enabled: true
```

and produces the same result (confirmed by the updated tests)

```
backend:
  workspace_key_prefix: test-test-component
backend_type: s3
remote_state_backend:
  workspace_key_prefix: test-test-component
remote_state_backend_type: s3
```


## references
* https://github.com/cloudposse/atmos/pull/77

