### PR TITLE
Bump `atmos` version. Disable component inheritance chain

### DIFF
--- a/examples/data-sources/utils_spacelift_stack_config/utils_spacelift_stack_config_test.go
+++ b/examples/data-sources/utils_spacelift_stack_config/utils_spacelift_stack_config_test.go
@@ -27,7 +27,7 @@ func TestSpaceliftStackProcessorWithTerraform(t *testing.T) {
 	terraform.OutputStruct(t, terraformOptions, "output", &output)
 	spaceliftStacks := output.(map[string]interface{})
 
-	assert.Equal(t, 30, len(spaceliftStacks))
+	assert.Equal(t, 24, len(spaceliftStacks))
 
 	tenant1Ue2DevInfraVpcStack := spaceliftStacks["tenant1-ue2-dev-infra-vpc"].(map[string]interface{})
 	tenant1Ue2DevInfraVpcStackInfrastructureStackName := tenant1Ue2DevInfraVpcStack["stack"].(string)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudposse/terraform-provider-utils
 go 1.16
 
 require (
-	github.com/cloudposse/atmos v1.3.10
+	github.com/cloudposse/atmos v1.3.11
 	github.com/gruntwork-io/terratest v0.38.6
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudposse/atmos v1.3.10 h1:VqJd5twMHO3kaR/OwInHPCdCtu8bDIXmmvuUxC4uMVE=
-github.com/cloudposse/atmos v1.3.10/go.mod h1:HK5MGGjlAoaethJL52KIjM164xONsoF81KCLON+zvg0=
+github.com/cloudposse/atmos v1.3.11 h1:6AMOjWSGQ57kNiFll3wv7wmiPcI7ByNcGIWPdU/wblY=
+github.com/cloudposse/atmos v1.3.11/go.mod h1:HK5MGGjlAoaethJL52KIjM164xONsoF81KCLON+zvg0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/internal/spacelift/spacelift_stack_processor_test.go
+++ b/internal/spacelift/spacelift_stack_processor_test.go
@@ -15,7 +15,7 @@ func TestSpaceliftStackProcessor(t *testing.T) {
 
 	var spaceliftStacks, err = s.CreateSpaceliftStacks("", nil, processStackDeps, processComponentDeps, processImports, stackConfigPathTemplate)
 	assert.Nil(t, err)
-	assert.Equal(t, 30, len(spaceliftStacks))
+	assert.Equal(t, 24, len(spaceliftStacks))
 
 	tenant1Ue2DevInfraVpcStack := spaceliftStacks["tenant1-ue2-dev-infra-vpc"].(map[string]interface{})
 	tenant1Ue2DevInfraVpcStackInfrastructureStackName := tenant1Ue2DevInfraVpcStack["stack"].(string)
@@ -82,7 +82,7 @@ func TestLegacySpaceliftStackProcessor(t *testing.T) {
 
 	var spaceliftStacks, err = s.CreateSpaceliftStacks(basePath, filePaths, processStackDeps, processComponentDeps, processImports, stackConfigPathTemplate)
 	assert.Nil(t, err)
-	assert.Equal(t, 30, len(spaceliftStacks))
+	assert.Equal(t, 24, len(spaceliftStacks))
 
 	tenant1Ue2DevInfraVpcStack := spaceliftStacks["tenant1-ue2-dev-infra-vpc"].(map[string]interface{})
 	tenant1Ue2DevInfraVpcStackBackend := tenant1Ue2DevInfraVpcStack["backend"].(map[interface{}]interface{})

--- a/internal/stack/stack_processor_test.go
+++ b/internal/stack/stack_processor_test.go
@@ -125,19 +125,20 @@ func TestStackProcessor(t *testing.T) {
 	assert.Equal(t, "top-level-component1", topLevelComponent1BackendWorkspaceKeyPrefix)
 	assert.Equal(t, "top-level-component1", topLevelComponent1RemoteStateBackendWorkspaceKeyPrefix)
 
-	testTestComponentOverrideComponent2 := terraformComponents["test/test-component-override-2"].(map[interface{}]interface{})
-	testTestComponentOverrideComponentBackend2 := testTestComponentOverrideComponent2["backend"].(map[interface{}]interface{})
-	testTestComponentOverrideComponentBackendType2 := testTestComponentOverrideComponent2["backend_type"]
-	testTestComponentOverrideComponentBackendWorkspaceKeyPrefix2 := testTestComponentOverrideComponentBackend2["workspace_key_prefix"]
-	testTestComponentOverrideComponentBackendBucket2 := testTestComponentOverrideComponentBackend2["bucket"]
-	testTestComponentOverrideComponentBaseComponent2 := testTestComponentOverrideComponent2["component"]
-	testTestComponentOverrideInheritance2 := testTestComponentOverrideComponent2["inheritance"].([]interface{})
-	assert.Equal(t, "test-test-component", testTestComponentOverrideComponentBackendWorkspaceKeyPrefix2)
-	assert.Equal(t, "eg-ue2-root-tfstate", testTestComponentOverrideComponentBackendBucket2)
-	assert.Equal(t, "test/test-component", testTestComponentOverrideComponentBaseComponent2)
-	assert.Equal(t, "s3", testTestComponentOverrideComponentBackendType2)
-	assert.Equal(t, "test/test-component-override", testTestComponentOverrideInheritance2[0])
-	assert.Equal(t, "test/test-component", testTestComponentOverrideInheritance2[1])
+	// TODO: uncomment after the inheritance chain is fixed
+	//testTestComponentOverrideComponent2 := terraformComponents["test/test-component-override-2"].(map[interface{}]interface{})
+	//testTestComponentOverrideComponentBackend2 := testTestComponentOverrideComponent2["backend"].(map[interface{}]interface{})
+	//testTestComponentOverrideComponentBackendType2 := testTestComponentOverrideComponent2["backend_type"]
+	//testTestComponentOverrideComponentBackendWorkspaceKeyPrefix2 := testTestComponentOverrideComponentBackend2["workspace_key_prefix"]
+	//testTestComponentOverrideComponentBackendBucket2 := testTestComponentOverrideComponentBackend2["bucket"]
+	//testTestComponentOverrideComponentBaseComponent2 := testTestComponentOverrideComponent2["component"]
+	//testTestComponentOverrideInheritance2 := testTestComponentOverrideComponent2["inheritance"].([]interface{})
+	//assert.Equal(t, "test-test-component", testTestComponentOverrideComponentBackendWorkspaceKeyPrefix2)
+	//assert.Equal(t, "eg-ue2-root-tfstate", testTestComponentOverrideComponentBackendBucket2)
+	//assert.Equal(t, "test/test-component", testTestComponentOverrideComponentBaseComponent2)
+	//assert.Equal(t, "s3", testTestComponentOverrideComponentBackendType2)
+	//assert.Equal(t, "test/test-component-override", testTestComponentOverrideInheritance2[0])
+	//assert.Equal(t, "test/test-component", testTestComponentOverrideInheritance2[1])
 
 	yamlConfig, err := yaml.Marshal(mapConfig1)
 	assert.Nil(t, err)


### PR DESCRIPTION
## what
* Bump `atmos` version
* Disable component inheritance chain for now

* While it's working in all the tests, and in 99% of the real infra stacks, some edge cases of stack config are not handled correctly and cause gorotine panic
* All edge cases will be tested and fixed in a consecutive PR

