### PR TITLE
Update `atmos`. Add `ignore_errors` input to `data_source_component_config`

### DIFF
--- a/examples/data-sources/utils_component_config/data-source.tf
+++ b/examples/data-sources/utils_component_config/data-source.tf
@@ -10,13 +10,15 @@ locals {
 }
 
 data "utils_component_config" "example1" {
-  component = local.component
-  stack     = local.stack
+  component     = local.component
+  stack         = local.stack
+  ignore_errors = false
 }
 
 data "utils_component_config" "example2" {
-  component   = local.component
-  tenant      = local.tenant
-  environment = local.environment
-  stage       = local.stage
+  component     = local.component
+  tenant        = local.tenant
+  environment   = local.environment
+  stage         = local.stage
+  ignore_errors = false
 }

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/cloudposse/terraform-provider-utils
 go 1.16
 
 require (
-	github.com/cloudposse/atmos v1.3.26
-	github.com/gruntwork-io/terratest v0.39.0
+	github.com/cloudposse/atmos v1.3.27
+	github.com/gruntwork-io/terratest v0.40.1
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudposse/atmos v1.3.26 h1:MsuL/ld1yJX+dprBzztyHq0MYm4xQ6C5S3BZy4Sd4/s=
-github.com/cloudposse/atmos v1.3.26/go.mod h1:QzJQBrCTMKjpqXPzm3qsXh4czWOsUj5Cy7uotYmC8+0=
+github.com/cloudposse/atmos v1.3.27 h1:BoSskR4mvVdepQbfUOZ84Co7kLM0qb7CzdfI62n5xE0=
+github.com/cloudposse/atmos v1.3.27/go.mod h1:9GFjoGygHdzF8B7eT4jQW3DjwS0EWjSE9Ig+ueT2kEg=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -515,8 +515,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.39.0 h1:Lq7aNCoFxhhmdQIyuBFBf8N87aCnypmNBFYgvsdIfCQ=
-github.com/gruntwork-io/terratest v0.39.0/go.mod h1:CjHsEgP1Pe987X5N8K5qEqCuLtu1bqERGIAF8bTj1s0=
+github.com/gruntwork-io/terratest v0.40.1 h1:xh9wniVkV0FujoEy56zWRylhmJEeu1gnKZGYf8+br9E=
+github.com/gruntwork-io/terratest v0.40.1/go.mod h1:CjHsEgP1Pe987X5N8K5qEqCuLtu1bqERGIAF8bTj1s0=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=


### PR DESCRIPTION
## what
* Update `atmos`
* Add `ignore_errors` input to `data_source_component_config`

## why
* Use latest code from `atmos` with new features and bug fixes
* `data_source_component_config` is used to read remote state of components. Sometimes we want to ignore errors if a component does not exist in a stack and just return an empty value

## references
* https://github.com/cloudposse/atmos/pull/120

