### PR TITLE
Update `atmos`. Add `init_run_reconfigure` CLI config. Update `stack_name_pattern`

### DIFF
--- a/examples/data-sources/utils_component_config/atmos.yaml
+++ b/examples/data-sources/utils_component_config/atmos.yaml
@@ -26,6 +26,8 @@ components:
     apply_auto_approve: false
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_INIT_RUN_RECONFIGURE` ENV var, or `--init-run-reconfigure` command-line argument
+    init_run_reconfigure: true
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_AUTO_GENERATE_BACKEND_FILE` ENV var, or `--auto-generate-backend-file` command-line argument
     auto_generate_backend_file: false
   helmfile:

--- a/examples/data-sources/utils_spacelift_stack_config/atmos.yaml
+++ b/examples/data-sources/utils_spacelift_stack_config/atmos.yaml
@@ -26,6 +26,8 @@ components:
     apply_auto_approve: false
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_INIT_RUN_RECONFIGURE` ENV var, or `--init-run-reconfigure` command-line argument
+    init_run_reconfigure: true
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_AUTO_GENERATE_BACKEND_FILE` ENV var, or `--auto-generate-backend-file` command-line argument
     auto_generate_backend_file: false
   helmfile:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudposse/terraform-provider-utils
 go 1.16
 
 require (
-	github.com/cloudposse/atmos v1.4.1
+	github.com/cloudposse/atmos v1.4.2
 	github.com/gruntwork-io/terratest v0.40.6
 	github.com/hashicorp/terraform-plugin-docs v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.13.0

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudposse/atmos v1.4.1 h1:pItIgj4qZ/v2PX+mcxoGTwJV0bUSdrENeiEuyNjHK6w=
-github.com/cloudposse/atmos v1.4.1/go.mod h1:9GFjoGygHdzF8B7eT4jQW3DjwS0EWjSE9Ig+ueT2kEg=
+github.com/cloudposse/atmos v1.4.2 h1:vT7fxPZPzmnpO09hnlbU+lpDLdukkzKw84tqxu0KC/s=
+github.com/cloudposse/atmos v1.4.2/go.mod h1:9GFjoGygHdzF8B7eT4jQW3DjwS0EWjSE9Ig+ueT2kEg=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/internal/component/atmos.yaml
+++ b/internal/component/atmos.yaml
@@ -26,6 +26,8 @@ components:
     apply_auto_approve: false
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_INIT_RUN_RECONFIGURE` ENV var, or `--init-run-reconfigure` command-line argument
+    init_run_reconfigure: true
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_AUTO_GENERATE_BACKEND_FILE` ENV var, or `--auto-generate-backend-file` command-line argument
     auto_generate_backend_file: false
   helmfile:

--- a/internal/spacelift/atmos.yaml
+++ b/internal/spacelift/atmos.yaml
@@ -26,6 +26,8 @@ components:
     apply_auto_approve: false
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_DEPLOY_RUN_INIT` ENV var, or `--deploy-run-init` command-line argument
     deploy_run_init: true
+    # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_INIT_RUN_RECONFIGURE` ENV var, or `--init-run-reconfigure` command-line argument
+    init_run_reconfigure: true
     # Can also be set using `ATMOS_COMPONENTS_TERRAFORM_AUTO_GENERATE_BACKEND_FILE` ENV var, or `--auto-generate-backend-file` command-line argument
     auto_generate_backend_file: false
   helmfile:


### PR DESCRIPTION
## what
* Update `atmos`
* Add `init_run_reconfigure` CLI config
* Update `stack_name_pattern`

## why
* `init_run_reconfigure` CLI config allows enabling/disabling the `-reconfigure` argument for `terraform init` when running it before running other terraform commands
* Don't use the default `stack_name_pattern` because it used `{tenant}` which is not available for all clients
* Running `terraform plan` and `terraform workspace` on abstract components creates terraform workspaces which is not needed

