### PR TITLE
ATMOS 1.10.1: Fix `atmos` CLI config processing. Improve `logs.verbose`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudposse/terraform-provider-utils
 go 1.19
 
 require (
-	github.com/cloudposse/atmos v1.10.0
+	github.com/cloudposse/atmos v1.10.1
 	github.com/gruntwork-io/terratest v0.40.22
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudposse/atmos v1.10.0 h1:6cpx1aZ82+EOINPS9saU+NkhaM6wbrGp/XL2C6fXLbs=
-github.com/cloudposse/atmos v1.10.0/go.mod h1:4oS6LVTW/Ejg1LkMDhEAim3VUsHOyDS8R32v4IZIOPo=
+github.com/cloudposse/atmos v1.10.1 h1:/O9ySmfbjGY5mglmKyYPQ/BZDVtnKNIv1Qt0eAJdN5g=
+github.com/cloudposse/atmos v1.10.1/go.mod h1:4oS6LVTW/Ejg1LkMDhEAim3VUsHOyDS8R32v4IZIOPo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
## what
* Fix `atmos` CLI config processing
* Improve `logs.verbose`

## why
* Fix issues with CLI config processing introduced in https://github.com/cloudposse/atmos/pull/210
* In `Go`, a struct is passed by value to a function (the whole struct is copied), so if the function modifies any struct fields, the changes are not visible from outside of the functions
* The function `processEnvVars` was accepting the CLI config struct by value, checking the ENV var `ATMOS_BASE_PATH` and modifying the `BasePath` field - this modification was lost when the function returned resulting in the error from the `utils` provider "failed to find a match for the import ..." because the `atmos` base path was not set correctly (note that `ATMOS_BASE_PATH` ENV var is critical for the `utils` provider to work, and it's set by `geodesic` or by Spacelift scripts)
* Changing the function to accept a pointer to the struct fixed the issue (the modified fields are visible to the calling code)

## references
* https://github.com/cloudposse/atmos/pull/211

