### PR TITLE
Bump `atmos` to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudposse/terraform-provider-utils
 go 1.19
 
 require (
-	github.com/cloudposse/atmos v1.26.0
+	github.com/cloudposse/atmos v1.26.1
 	github.com/gruntwork-io/terratest v0.41.10
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.1.0 h1:bZgT/A+cikZnKIwn7xL2OBj012Bmvho/o6RpRvv3GKY=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
-github.com/cloudposse/atmos v1.26.0 h1:68PbPS6KkMMEIim8Y0zp46LB0GfoINTDYHhzdP1NhM0=
-github.com/cloudposse/atmos v1.26.0/go.mod h1:r04BmdpZmbHDhFujfvRbIXC+KpSVyumrGf55eaWTbKQ=
+github.com/cloudposse/atmos v1.26.1 h1:9jENZv+Oo8cjLQvWPmj7qsSy7yScuKwNJsWoFvceMyg=
+github.com/cloudposse/atmos v1.26.1/go.mod h1:r04BmdpZmbHDhFujfvRbIXC+KpSVyumrGf55eaWTbKQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
## what
* Bump `atmos` to 1.26.1

## why
* Update `Go` templates in stack configs
* If a `context` is not provided (as if using `import` with `context`), don't process `Go` templates in the imported configurations (templating can be used for Datadog, ArgoCD etc. w/o requiring Atmos to process them)

## references
* https://github.com/cloudposse/atmos/releases/tag/v1.26.1
