### PR TITLE
Fix golang version for building release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "*"
+
+  workflow_dispatch:
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3.3.0
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
## what

- Fix `go` version for building release artifacts


## why

- Need to build with `go` version 1.20, not 1.2

