### PR TITLE
Install terraform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,12 @@ jobs:
           go-version-file: go.mod
         id: go
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+
       - name: Get dependencies
         run: |
           make deps


### PR DESCRIPTION
## what
* Install terraform

## why
* New Github action public runners do not have terraform by default

## references
* https://github.com/gruntwork-io/terratest/issues/1388
