### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ on:
   release:
     types: [published]
 
-permissions: {}
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## what
* Fix release workflow

## why
* Release workflow put's comments into PRs that it is released. Permissions required

## references
* https://github.com/cloudposse/terraform-provider-utils/actions/runs/17445640722
