### PR TITLE
Fix goreleaser config for v1 compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,3 @@
-version: 2
-
 # Local goreleaser config — overrides the org-wide config at cloudposse/.github/.github/goreleaser.yml
 # Needed because Go 1.24+ dropped support for windows/arm (32-bit), which the shared config includes.
 
@@ -10,7 +8,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.FullCommit}}'
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
     - freebsd
     - windows


### PR DESCRIPTION
## what

- Remove `version: 2` header from `.goreleaser.yml` — GoReleaser v1 does not support it
- Revert `.FullCommit` back to `.Commit` in ldflags — `.FullCommit` is a GoReleaser v2 template variable

## why

- The shared release workflow (`cloudposse/.github`) uses GoReleaser **v1** (v1.26.2)
- PR #523 added `version: 2` and `.FullCommit` per a CodeRabbit AI suggestion, but the suggestion didn't account for the CI pinning GoReleaser v1
- This caused the release CI to fail with: `only configurations files on version: 1 are supported, yours is version: 2`

## references

- Failed CI run: https://github.com/cloudposse/terraform-provider-utils/actions/runs/22242392677/job/64349188250
- Original change introduced in #523