### PR TITLE
Add manual release workflow for arbitrary tags

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -63,8 +63,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
         run: |
-          LATEST_FLAG=""
           if [ "${{ inputs.make_latest }}" = "true" ]; then
-            LATEST_FLAG="--latest"
+            gh release edit "${TAG}" --draft=false --latest
+          else
+            gh release edit "${TAG}" --draft=false --latest=false
           fi
-          gh release edit "${TAG}" --draft=false $LATEST_FLAG


### PR DESCRIPTION
## what

- Add a new `workflow_dispatch` workflow (`.github/workflows/manual-release.yml`) that allows manually triggering a release for any existing git tag
- Supports building binaries, GPG signing, and publishing via GoReleaser
- Includes a `make_latest` option to control whether the release is marked as "Latest"

## why

- The auto-release workflow (`shared-go-auto-release.yml`) always bumps from the highest semver tag, which produces v2.x releases
- We need to create v1.x releases (e.g. v1.32.0) for downstream `remote-state` modules that pin the provider to `< 2`
- This workflow enables creating properly signed releases for any tag without modifying the existing auto-release pipeline

## references

- v2.1.0 release was auto-created when we needed v1.32.0: https://github.com/cloudposse/terraform-provider-utils/releases/tag/v2.1.0