### PR TITLE
Fix manual release workflow: patch goreleaser config and bump timeout

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --clean --timeout 30m
+          args: release --clean --timeout 45m
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## what

- Add a `sed` step to replace `{{ .Env.ARCHIVES_FORMAT }}` with `zip` in `.goreleaser.yml` before GoReleaser runs
- Bump job timeout from 30m to 45m

## why

- GoReleaser v1 does not expand `{{ .Env.ARCHIVES_FORMAT }}` in the `archives.format` field, causing `invalid archive format` error
- The shared auto-release workflow (`shared-go-auto-release.yml`) handles this with the same `sed` approach
- The build took 28m33s, which is dangerously close to the 30m timeout

## references

- Manual release workflow PR: #528
- Failed workflow run: https://github.com/cloudposse/terraform-provider-utils/actions/runs/22971544802