### PR TITLE
Fix goreleaser dirty git state in manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -50,13 +50,14 @@ jobs:
 
       - name: Patch goreleaser config
         run: |
-          sed -i 's/{{ .Env.ARCHIVES_FORMAT }}/zip/g' .goreleaser.yml
+          cp .goreleaser.yml /tmp/.goreleaser-patched.yml
+          sed -i 's/{{ .Env.ARCHIVES_FORMAT }}/zip/g' /tmp/.goreleaser-patched.yml
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --clean --timeout 45m
+          args: release --config /tmp/.goreleaser-patched.yml --clean --timeout 45m
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## what

- Copy `.goreleaser.yml` to `/tmp/` and run `sed` on the copy instead of modifying the repo file
- Pass `--config /tmp/.goreleaser-patched.yml` to GoReleaser

## why

- The `sed` command that replaces `{{ .Env.ARCHIVES_FORMAT }}` was modifying `.goreleaser.yml` in-place, causing GoReleaser to fail with `git is in a dirty state`
- The shared auto-release workflow avoids this by copying the config to a separate directory before patching — this follows the same pattern

## references

- Failed workflow run: https://github.com/cloudposse/terraform-provider-utils/actions/workflows/manual-release.yml
- PR #529