### PR TITLE
Set GO_RELEASER_TARGET_COMMITISH in manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -61,6 +61,7 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GO_RELEASER_TARGET_COMMITISH: main
 
       - name: Publish release
         env:


### PR DESCRIPTION
## what

- Set `GO_RELEASER_TARGET_COMMITISH: main` env var for the GoReleaser step

## why

- GoReleaser checks out at the tag (detached HEAD), so `{{ .Branch }}` resolves to `HEAD`
- The `.goreleaser.yml` uses `GO_RELEASER_TARGET_COMMITISH` as `target_commitish` for the GitHub release, falling back to `{{ .Branch }}`
- GitHub API rejects `HEAD` as an invalid `target_commitish`, causing: `POST .../releases: 422 Validation Failed [{Resource:Release Field:target_commitish Code:invalid}]`
- The shared auto-release workflow sets this env var — our manual workflow was missing it

## references

- Failed workflow run: https://github.com/cloudposse/terraform-provider-utils/actions/workflows/manual-release.yml
- PR #530, PR #529